### PR TITLE
29_3種別に予定表の色分け修正_edit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'turbolinks',   '~> 5'
 gem 'jbuilder',     '~> 2.5'
 gem 'ranked-model'
 gem 'jquery-ui-rails'
+gem 'holiday_japan'
 
 group :development, :test do
   gem 'sqlite3', '1.3.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    holiday_japan (1.4.3)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
@@ -190,6 +191,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
   faker
+  holiday_japan
   jbuilder (~> 2.5)
   jquery-rails
   jquery-ui-rails

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -38,6 +38,7 @@ class LessonsController < ApplicationController
     finishtime=lesson_params[:finishtime].to_time
     autoregister=lesson_params[:autoregister]
     openday=lesson_params[:meeting_on]
+    fixtimeres=lesson_params[:fixtimeres]
     lesson.started_at=starttime+54000
     lesson.finished_at=finishtime+54000
     if lesson_params[:examineekanji]=="受験生"
@@ -77,6 +78,11 @@ class LessonsController < ApplicationController
       if lesson.regular? and autoregister=="1" #定例授業なら該当の生徒を自動で登録する
         #会員で該当曜日３つカラムから該当曜日の生徒抽出
         students=Student.where("fix_day =? or fix_day2 =? or fix_day3 =?",dayofweek,dayofweek,dayofweek).where(withdrawal:nil)
+        if fixtimeres=="1" #固定時間のあってる人のみ抽出し自動登録
+          students=students.where("fix_time >=? and fix_time <=?",lesson.started_at,lesson.finished_at)
+          .or(students.where("fix_time2 >=? and fix_time2 <=?",lesson.started_at,lesson.finished_at))
+          .or(students.where("fix_time3 >=? and fix_time3 <=?",lesson.started_at,lesson.finished_at))
+        end
         if lesson_params[:target]=="中学生" && lesson.examinee==true #中学生で受験生を自動登録
           rev=students.where("birthday < ? and examinee=?" ,jrhigh(lesson.meeting_on).to_date,true)
         elsif lesson_params[:target]=="中学生" && lesson.examinee==false #中学生で受験生以外を自動登録
@@ -143,6 +149,6 @@ class LessonsController < ApplicationController
   
   private
   def lesson_params
-     params.require(:lesson).permit(:meeting_on, :target,:examineekanji,:starttime,:finishtime,:seats_real,:seats_zoom,:autoregister,:regularkanji,:note)
+     params.require(:lesson).permit(:meeting_on, :target,:examineekanji,:starttime,:finishtime,:seats_real,:seats_zoom,:autoregister,:regularkanji,:note,:fixtimeres)
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -4,7 +4,11 @@ class ReservationsController < ApplicationController
   require 'date'
   
   def index
+  
   end
+  
+  
+  
   
   def reservations_log
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@ class UsersController < ApplicationController
   
   def index
     @users = User.paginate(page: params[:page], per_page: 20)
+    @students=Student.all
   end
   
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,6 +94,11 @@ module ApplicationHelper
     h(str).gsub(/\R/, "<br>")
   end
   
+  def holiday(d)
+    holidayreturn=HolidayJapan.check(Date.new(d.year,d.month,d.day))
+    holidayreturn
+  end
+  
   class Listcollection
   attr_accessor :id,:content
     def initialize(id,content,zoom)
@@ -101,5 +106,32 @@ module ApplicationHelper
       @content=content
     end
   end
-  
+  def tdbgcolor(thisday,day,section)
+    if day==thisday && section==1
+      bgcolor="#f8f8ff"
+    elsif day.wday==0  or holiday(day)
+      bgcolor="#ffede6"
+    elsif day.wday==6
+      bgcolor="#e0ffff"
+    elsif section==2
+      bgcolor="#f5f5dc"
+    else
+      bgcolor="#fffafa"
+    end
+    bgcolor
+  end
+  def tdcellbgcolor(thisday,day,section)
+    if day==thisday && section==1
+      bgcolor="#e9967a"
+    elsif day.wday==0  or holiday(day)
+      bgcolor="#ffede6"
+    elsif day.wday==6
+      bgcolor="#e0ffff"
+    elsif section==2
+      bgcolor="#dcdcdc"
+    else
+      bgcolor="#fffafa"
+    end
+    bgcolor
+  end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,5 +1,4 @@
 class Lesson < ApplicationRecord
-
   belongs_to :user
   has_many :reservations, dependent: :destroy
   attr_accessor :regularkanji
@@ -7,4 +6,5 @@ class Lesson < ApplicationRecord
   attr_accessor :starttime
   attr_accessor :finishtime
   attr_accessor :autoregister
+  attr_accessor:fixtimeres
 end

--- a/app/views/lessons/weeklyschedule.html.erb
+++ b/app/views/lessons/weeklyschedule.html.erb
@@ -1,5 +1,6 @@
 <% require 'date' %>
-<% thisday=Date.today %>
+<% nowtime=Time.new+32400  %>
+<% thisday=nowtime.to_date %>
 <% first_day=@today.to_date %>
 <% datedown=(first_day-7) %>
 <% dateup=(first_day+7) %>
@@ -8,14 +9,16 @@
 <% last_time="2000-01-01 22:30".to_time %>
 <% @student=Student.find(session[:student_id]) if session[:student_id].present? %>
 <% if @students.count>=2 %>
-<div style="padding-left:100px;"></div>
+<div style="padding-left:170px;">
 <% @students.each do |student| %>
 <div style="display: inline-block;">
   <% studentid=student.id %>
+  <%# cenceln="(#{student.cancelnumber.to_s})" if student.cancelnumber.present? %>
   <%= button_to student.student_name, {controller: 'lessons', action: 'weeklyschedule'}, {method: :get, params: {changestudent:studentid,cation:"2"}} %>
   &nbsp;</div>
 <% end %>
 <% end %>
+</div>
 <div style="text-align:center">
   <div style="display: inline-block;"><%= button_to"←", {controller: 'lessons', action: 'weeklyschedule'}, {method: :get, params: {changeday:datedown,cation:"1"}} %></div>
   <div style="display: inline-block;">
@@ -45,8 +48,7 @@
         </tr>
         <% end %>
       </table>
-
-      <% (first_day..last_day).each do |day| %>
+  <% (first_day..last_day).each do |day| %>
   <th>
   <td>
     <table border="2" class="table" style="width:105px; vertical-align:top;">
@@ -77,7 +79,7 @@
                   <%= f.select :starttime, @hourselect, {}, required: true, class: "form-control new-form" %>
                 </div>
                 <div class="form-group">
-                  <label for="select1a">終了時間:</label>
+                  <label for="select1a">終了時間:</label>　
                   <%= f.select :finishtime, @hourselect, {}, required: true, class: "form-control new-form" %>
                 </div>
                 <div class="form-group">
@@ -89,7 +91,7 @@
                   <%= f.select:seats_zoom,@capacity, {selected:5},class: "form-control new-form" %>
                 </div>
                 <div class="form-group">
-                  <label for="select1a">区分:</label>　※定例授業で対象生徒を自動登録する<%= f.check_box :autoregister, {:checked => true} %> 
+                  <label for="select1a">区分:</label>　<%= f.check_box :autoregister, {:checked => true} %> 定例で生徒を予約登録　<%= f.check_box :fixtimeres, {:checked => true} %> 定例で固定時間の合う生徒だけ予約登録
                   <%= f.select :regularkanji, [["定例"],["臨時"]], {}, required: true, class: "form-control new-form" %>
                 </div>
                 <%= f.hidden_field :meeting_on,value:day  %>
@@ -113,7 +115,7 @@
       <!--授業新規モーダルここまで -->
       <% end %>
       <tr>
-        <td align="center" bgcolor="#f2f2f2" style="border-bottom: 1px solid;"><%=day.day %>日(<%=weekdate(day) %>)</td>
+        <td align="center" bgcolor=<%= tdbgcolor(thisday,day,2) %> style="border-bottom: 1px solid;"><%=day.day %>日(<%=weekdate(day) %>)</td>
       </tr>
       <% time = first_time %>
       <% coursecount=0 %>
@@ -130,18 +132,30 @@
           <% else %>
             <% rev=Reservation.where("lesson_id =? and student_id=?" ,lesson.id,@student.id).present?  %>
           <% end %>
-          <% if rev.present? and current_user.admin==false %>
-            <% tdcolor="#d3d3d3" %>
-          <% else %>
+          <% gradesc=gradeschool(@student.birthday,lesson.meeting_on) if current_user.admin==false %>
+          <% if rev.present? and current_user.admin==true %>
             <% tdcolor="#c0ffc0" %>
+          <% elsif ((lesson.target==gradesc or lesson.target=="小中学生") and (lesson.examinee==nil or lesson.examinee==@student.examinee) and  @student.cancelnumber.present? and @student.cancelnumber>0  and lesson.meeting_on.to_date>thisday) or ((lesson.target==gradesc or lesson.target=="小中学生") and lesson.regular==false) %>
+            <% selection=1 %>
+            <% if rev.present? %>
+              <% tdcolor="#c0ffc0" %>
+            <% else %>
+              <% tdcolor="#fffacd" %>
+            <% end %>
+          <% elsif rev.present? and current_user.admin==false %>
+            <% tdcolor="#c0ffc0" %>
+          <% elsif rev.present? and current_user.admin==false %>
+            <% tdcolor="#c0ffc0" %>
+          <% else %>
+            <% tdcolor="#d3d3d3" %>
           <% end %>
           <td bgcolor=<%=tdcolor %>>
-        <% gradesc=gradeschool(@student.birthday,lesson.meeting_on) if current_user.admin==false %>
+        
           <% if current_user.admin? %>
             <%= link_to lesson.target, "/attendances/lesson_detail/#{lesson.id}" %>
           <% elsif rev.present? %>
             <%= link_to lesson.target, {controller: 'reservationusers', action: 'useredit',lesson_id:lesson.id,student_id:@student.id}, {method: :post} %>
-          <% elsif ((lesson.target==gradesc or lesson.target=="小中学生") and (lesson.examinee==nil or lesson.examinee==@student.examinee) and  @student.cancelnumber.present? and @student.cancelnumber>0  and lesson.meeting_on.to_date>thisday) or ((lesson.target==gradesc or lesson.target=="小中学生") and lesson.regular==false) %>
+          <% elsif selection==1 %>
             <%= link_to lesson.target, {controller: 'reservationusers', action: 'reservationnewuser',lesson_id:lesson.id,student_id:@student.id}, {method: :post} %>
           <% else %>
             <%= lesson.target %>
@@ -162,11 +176,7 @@
           &nbsp;
           <% end %>
           <% else %>
-          <%if day.wday==0 || day.wday==6 %>
-        <td bgcolor="#ffede6">
-          <% else %>
-        <td>
-          <% end %>
+            <td bgcolor=<%= tdbgcolor(thisday,day,1) %>>
           &nbsp;
           <% end %>
         </td>

--- a/app/views/reservationusers/reservationnewuser.html.erb
+++ b/app/views/reservationusers/reservationnewuser.html.erb
@@ -34,10 +34,10 @@
       <%= f.hidden_field :reservation_id,value:@reservation.id %>
       <%= f.hidden_field :student_id,value:@student.id %>
       <%= f.hidden_field :lesson_id,value:@lesson.id %>
-    <tr style="border-top: solid midnightblue;"><td>備考</td><td><%=@reservation.note %></td>
+    <tr style="border-top: solid midnightblue;"><td>備考</td><td><%=@lesson.note %></td>
     </table>
       <% if @lesson.meeting_on>thisday %>
-        <%= f.submit "振替授業新規登録", class: "btn btn-primary" %>&nbsp;
+        <%= f.submit "授業新規登録", class: "btn btn-primary" %>&nbsp;
       <% end %>
     <% end %>
     <% if @beforesite.present? %>

--- a/app/views/reservationusers/useredit.html.erb
+++ b/app/views/reservationusers/useredit.html.erb
@@ -5,19 +5,41 @@
   <div class="col-md-6 col-md-offset-3 lead">
     
     <table border="2" class="table" style="border : 2px solid midnightblue ;">
-    <tr ><td style="width:150px;">コース</td><td><%= @lesson.target %>コース</td></tr>  
+    <tr ><td style="width:150px;">コース</td><td><%= @lesson.target %>
+    <% if @lesson.examinee==true %>
+    受験生 
+    <% elsif @lesson.examinee==true %>
+    一般
+    <% end %>
+    コース
+    <% if @reservation.waiting==true %>
+      <span class="label label-danger">キャンセル待ち</span>
+    <% else %>
+      <span class="label label-info">予約済</span>
+    <% end %>
+    </td></tr>  
     <tr style="border-top: solid  midnightblue;"><td style="width:150px;">名前</td><td><%= @student.student_name %></td></tr>
     <tr style="border-top:  solid midnightblue;"><td>予約日時</td>
     <td>
     <%= daydis(@lesson.meeting_on) %>(<%=weekdate(@lesson.meeting_on) %>)<%=timedisplay(@lesson.started_at) %>〜<%=timedisplay(@lesson.finished_at) %>
-    <% if @reservation.transfer? %>
+    <% if @reservation.transfer==true %>
      振替　
     <% end %>
     <% if @reservation.absence? %>
-      欠席　
+      <span class="label label-danger">欠席</span>
+    <% end %>
+    <% if @lesson.regular==false %>
+      <span class="label label-danger">臨時</span>
     <% end %>
     </td></tr>
-    <tr style="border-top:  solid midnightblue;"><td>固定時間</td><td><%=timedisplay(@reservation.fix_time) if @reservation.fix_time.present? %></td>
+    <tr style="border-top:  solid midnightblue;"><td>固定時間</td>
+    <td>
+    <% if @reservation.fix_time.present? %>
+    <%=timedisplay(@reservation.fix_time)  %>
+    <% else %>
+    <span class="label label-danger">未設定</span>
+    <% end %>
+    </td>
     <tr style="border-top: solid midnightblue;"><td>授業方法</td>
     <td>
       <% zoomseat=@lesson.seats_zoom %>
@@ -32,15 +54,24 @@
     </table>
     <% modaltype1="chengesc" %><% modaltype="newsc" %>
     <% if @lesson.meeting_on>@today %>
-      <a href="" data-toggle="modal" data-target=#modal1 class="btn btn-primary">授業方法変更登録</a>&nbsp;
-      <a href="" data-toggle="modal" data-target=#<%=modaltype%> class="btn btn-primary">キャンセル登録</a>&nbsp;
+      <a href="" data-toggle="modal" data-target=#modal1 class="btn btn-success">授業方法変更登録</a>&nbsp;
+      <% if @lesson.regular==true %>
+      <div style="display: inline-block;">
+        <a href="" data-toggle="modal" data-target=#<%=modaltype%> class="btn btn-warning">キャンセル登録</a>&nbsp;
+      </div>
+      <% else %>
+      <div style="display: inline-block;">
+        <%= button_to "キャンセル登録", {controller: 'reservationusers', action: 'reservation_delete'}, {method: :get, params: {reservation_id:@reservation.id},class:"btn btn-warning"} %>
+      </div>
+      <% end %>
     <% end %>
+    <div style="display: inline-block;">
     <% if @beforesite.present? %>
       <%= link_to "前のページに戻る" ,@beforesite %>
     <% else %>
       <%=link_to "カレンダーに戻る","/lessons/weeklyschedule?cation=1&changeday=#{lesson.meeting_on.to_s}" %>
     <% end %>
-    </p>
+    </div>
     <% modaltype="newsc" %>
     
   </div>
@@ -54,10 +85,10 @@
       <% realseat=@lesson.seats_real %>
     <div>本当に授業方法を変更しますか？
     <% if (@realnumber-realseat)>=0 %>
-      ※リアルは満席です。キャンセル待ちになります
+      ※リアルは満席です。キャンセル待ちになります。
     <% end %>
     <% if (@zoomnumber-zoomseat)>=0 %>
-      ※Zoomは満席です。キャンセル待ちになります
+      ※Zoomは満席です。キャンセル待ちになります.
     <% end %>
     </div></div>
     <div class="modal-footer">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   post 'reservationusers/useredit', to: 'reservationusers#useredit'
   get 'reservationusers/useredit', to: 'reservationusers#useredit'
   post 'reservationusers/userupdate', to: 'reservationusers#userupdate'
+  get 'reservationusers/reservation_delete', to: 'reservationusers#reservation_delete'
   post 'reservationusers/reservation_change_user', to: 'reservationusers#reservation_change_user'
   post 'reservationusers/reservationnewuser', to: 'reservationusers#reservationnewuser'
   post 'reservationusers/reservationnewusercreate', to: 'reservationusers#reservationnewusercreate'


### PR DESCRIPTION
週間予定表の種別色分け
　　予約登録済　　薄緑
　　予約不可　　　紺色
　　予約可能　　　レモン色
　　※基本的には対象曜日に自動登録され、キャンセルする場合は振替日を選択するので
　　　予約可能となるケースは滅多にないが、振替日を登録しないままキャンセルすれば
　　　予約可能な日分が　レモン色になる
　
曜日毎色分け
土曜日　青　日曜祝日　ピンク　当日　薄黄色


授業登録時
　　固定時間があってる生徒のみ自動予約するシステム追加（チェックを入れなければ従来
　　通りその曜日の対象生徒が全部登録される）
　　休みの日は、授業が昼と夜の２本だてになることへの対策です。
　
