### PR TITLE
51 reservation edit

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -18,12 +18,6 @@ textarea {
   resize: vertical;
 }
 
-input, button, textarea, select {
-    font-family: auto;
-    -moz-appearance: none;
-    appearance: none;
-}
-
 .center {
   text-align: center;
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -18,6 +18,12 @@ textarea {
   resize: vertical;
 }
 
+input, button, textarea, select {
+    font-family: auto;
+    -moz-appearance: none;
+    appearance: none;
+}
+
 .center {
   text-align: center;
 }

--- a/app/assets/stylesheets/reservations.scss
+++ b/app/assets/stylesheets/reservations.scss
@@ -1,3 +1,6 @@
+@import "bootstrap-sprockets";
+@import "bootstrap";
+
 #table-reservations {
   width: 100%;
   vertical-align: middle;
@@ -20,4 +23,8 @@
     vertical-align: middle;
     text-align: center;
   }
+}
+
+select {
+  height: 1.7em;
 }

--- a/app/assets/stylesheets/reservations.scss
+++ b/app/assets/stylesheets/reservations.scss
@@ -1,6 +1,3 @@
-@import "bootstrap-sprockets";
-@import "bootstrap";
-
 #table-reservations {
   width: 100%;
   vertical-align: middle;
@@ -8,6 +5,10 @@
   th {
     vertical-align: middle;
     text-align: center;
+    font-size: 130%;
+  }
+  td {
+    font-size: 150%;
     font-size: 130%;
   }
   td {
@@ -24,6 +25,11 @@
     text-align: center;
   }
 }
+
+select {
+  height: 1.7em;
+}
+
 
 select {
   height: 1.7em;

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -63,6 +63,15 @@ class ReservationsController < ApplicationController
         end
        redirect_to request.referrer and return
     end
+    
+    if params[:no] == "7"
+        if @reservation.update_attributes(waiting: false)
+          flash[:success] = "キャンセル待ちを解除して授業枠の登録をしました。"
+        else
+          flash[:danger] = "キャンセル待ちを解除して授業枠の登録に失敗しました。"
+        end
+       redirect_to request.referrer and return
+    end
   end
 
   

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -2,6 +2,8 @@ class Reservation < ApplicationRecord
   belongs_to :user
   belongs_to :lesson
   belongs_to :student
+  
+  default_scope -> { order(fix_time: :asc) }
 
   def self.log_order
     includes(:lesson).order("lessons.meeting_on DESC").order("lessons.started_at DESC")

--- a/app/views/lessons/lesson_detail.html.erb
+++ b/app/views/lessons/lesson_detail.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, '予約状況') %>
 
-<h1>【予約詳細・出欠管理】</h1>
+<h1>【予約詳細】</h1>
 
 <div class="col-md-10 col-md-offset-1">
   <div class="lesson-discontinuation-fix-btn">
@@ -44,7 +44,7 @@
   </table>
 
 　<table class="table table-bordered table-condensed" id="table-reservations">
-     <h1 class="modal-title center">【生徒】</h1>
+     <h1 class="modal-title center">【予約生徒・修正&出欠管理】</h1>
          <tr>
            <th>名前</th>
            <th>振替</th>

--- a/app/views/lessons/lesson_detail.html.erb
+++ b/app/views/lessons/lesson_detail.html.erb
@@ -5,7 +5,7 @@
 <div class="col-md-10 col-md-offset-1">
   <div class="lesson-discontinuation-fix-btn">
     <td><a href="" data-toggle="modal" data-target=#modal2 class="btn btn-warning button_size">生徒追加</a></td>
-    <td><%= link_to "修正・中止", lesson_discontinuation_fix_lesson_path(@lesson), remote: true, class: "btn btn-danger btn-sm" %></td>
+    <td><%= link_to "修正・中止", lesson_discontinuation_fix_lesson_path(@lesson), remote: true, class: "btn btn-danger" %></td>
   </div>
 
   <table class="table table-bordered table-condensed" id="table-reservations">
@@ -45,19 +45,22 @@
 
 　<table class="table table-bordered table-condensed" id="table-reservations">
      <h1 class="modal-title center">【生徒】</h1>
+         <tr>
+           <th>名前</th>
+           <th>振替</th>
+           <th>固定時間</th>
+           <th>授業方法</th>
+           <th>
+             固定時間/授業方法<br>
+             修正ボタン
+           </th>
+           <th>出席時間</th>
+           <th>退席時間</th>
+           <th>欠席</th>
+           <th>出欠ボタン</th>
+         </tr>
       <% @reservations.each do |reservation| %>
         <% if reservation.waiting == false %>
-           <tr>
-             <th>名前</th>
-             <th>振替</th>
-             <th>固定時間</th>
-             <th>授業方法</th>
-             <th>固定時間方法修正</th>
-             <th>出席時間</th>
-             <th>退席時間</th>
-             <th>欠席</th>
-             <th>出欠ボタン</th>
-           </tr>
            <tr>
             <td>
               <%= link_to reservation.student.student_name, "/reservationusers/useredit?lesson_id=#{@lesson.id}&student_id=#{reservation.student_id}"  %>
@@ -75,8 +78,8 @@
               <%= form_with(model: reservation, url: reservation_path(reservation, no: 6), method: :patch, local:true) do |f| %>
                 <%= f.time_field :fix_time %>
             </td>
-            <td><%= f.select :zoom, {zoom: true, "リアル": false} %></td>
-            <td>  <%= f.submit '修正', class: "btn btn-warning" %></td>
+            <td><%= f.select :zoom, {"ZOOM": true, "リアル": false} %></td>
+            <td>  <%= f.submit '修正', class: "btn btn-warning btn-sm" %></td>
               <% end %>
             <td><%= l(reservation.attendance_time, format: :time, default: '-') %></td>
             <td><%= l(reservation.leave_time, format: :time, default: '-') %></td>
@@ -90,21 +93,21 @@
             </td>
             <td>
               <% if reservation.attendance_time.nil? && reservation.absence == false %>
-                <%= link_to "出席", reservation_path(reservation, no: 1), method: :patch, class: "btn btn-primary" %>
+                <%= link_to "出席", reservation_path(reservation, no: 1), method: :patch, class: "btn btn-primary btn-sm" %>
               <% end %>
     
               <% if reservation.leave_time.nil? && reservation.attendance_time.present? %>
-                <%= link_to "退席", reservation_path(reservation, no: 2), method: :patch, class: "btn btn-success" %>
+                <%= link_to "退席", reservation_path(reservation, no: 2), method: :patch, class: "btn btn-success btn-sm" %>
               <% end %>
               
               <% if reservation.attendance_time.present? %>
               <%= link_to "クリア", reservation_path(reservation, no: 3), method: :patch,
                   data: { confirm: "出席と退席時間をクリアしてもよろしいですか？" },
-                  class: "btn btn-info" %>
+                  class: "btn btn-info btn-sm" %>
               <% end %>
               
               <% if reservation.attendance_time.nil? && reservation.absence == false %>
-                <%= link_to "欠席", reservation_path(reservation, no: 4), method: :patch, class:"btn btn-danger" %>
+                <%= link_to "欠席", reservation_path(reservation, no: 4), method: :patch, class:"btn btn-danger btn-sm" %>
               <% end %>
               
               <% if reservation.absence.present? %>
@@ -120,25 +123,33 @@
 　　　　　　
 　<table class="table table-bordered table-condensed" id="table-reservations">
      <h1 class="modal-title center">【キャンセル待ち】</h1>
-      <% @reservations.each do |reservation| %>
-        <% if reservation.waiting == true %>
            <tr>
             <th>名前</th>
             <th>固定時間</th>
             <th>授業方法</th>
             <th>登録ボタン</th>
            </tr>
+    　<% @reservations.each do |reservation| %>
+        <% if reservation.waiting == true %>
            <tr>
             <td>
               <%= link_to reservation.student.student_name, "/reservationusers/useredit?lesson_id=#{@lesson.id}&student_id=#{reservation.student_id}"  %>
             </td>
+            <td><%= l(reservation.fix_time, format: :time, default: '-') %></td>
             <td>
-              <%= form_with(model: reservation, url: reservation_path(reservation, no: 6), method: :patch, local:true) do |f| %>
-                <%= f.time_field :fix_time %>
-            </td>
-            <td><%= f.select :zoom, {zoom: true, "リアル": false} %></td>
-            <td>  <%= f.submit '登録', class: "btn btn-primary" %></td>
+              <% if reservation.zoom == true %>
+                <span class="label label-info label-user-division">ZOOM</span>
               <% end %>
+              
+              <% if reservation.zoom == false %>
+                <span class="label label-success label-user-division">リアル</span>
+              <% end %>
+            </td>
+            <td>
+              <%= link_to "キャンセル待ち解除 & 授業枠登録", reservation_path(reservation, no: 7), method: :patch,
+                data: { confirm: "キャンセル待ちを解除して授業予約登録しますがよろしいですか？" },
+                class: "btn btn-primary" %>
+            </td>
            </tr>
         <% end %>
       <% end %>


### PR DESCRIPTION
予約詳細・出欠管理ページについて修正しました。

1.【生徒】一覧の固定時間の降順機能実装完了
2.【生徒】【キャンセル待ち】一覧の項目名は先頭のみ表示完了
3.【キャンセル待ち】一覧のキャンセル待ち解除&授業枠登録ボタン機能実装
4.　固定時間のテキストボックスと授業方法セレクトボックスの高さ合わせました。
5.　３文字までのボタンの大きさ統一しました。（３文字はフォント小さくする）
6.　各タイトルを各表に合わせて変更

レビューお願いします。