### PR TITLE
 55_1メール機能追加 ユーザ―側予約取消機能修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  require 'date'
   include SessionsHelper
   #時間修正値9時間（秒）
   TIMECOL = 32400
@@ -7,7 +8,7 @@ class ApplicationController < ActionController::Base
 
   #学校を配列に
   def schoolgrade
-     @grade= ["小学生", "中学生","小中学生"]
+     @grade= ["小学生", "中学生","小中高生"]
   end
   #管理者でなければログイン画面に推移する
   def  unlessadmintransition
@@ -55,5 +56,9 @@ class ApplicationController < ActionController::Base
   end
   def weekday
     @weekday = ["月","火","水","木","金","土","日"]
+  end
+  def day_setting
+    nowtime = Time.new + TIMECOL
+    @today = nowtime.to_date
   end
 end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -2,12 +2,13 @@ class LessonsController < ApplicationController
   before_action :schoolgrade
   before_action :set_student
   before_action :set_lesson
+  
   require 'date'
   include ApplicationHelper
   
   def weeklyschedule
-    @timecol=TIMECOL
-    if params[:cation]=="1"
+    @timecol = TIMECOL
+    if params[:cation] == "1"
       @today=params[:changeday].to_date
     else
       nowtime=Time.new+@timecol

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -102,11 +102,12 @@ class LessonsController < ApplicationController
   
   def lesson_detail
     @lesson = Lesson.find(params[:id])
-    @reservations = Reservation.where("lesson_id = ?", @lesson.id)
-    @zooms_sum = Reservation.where("lesson_id = ? and zoom = ?", @lesson.id,true).count
-    @reals_sum = Reservation.where("lesson_id = ? and zoom = ?", @lesson.id,false).count
+    @reservations = Reservation.where("lesson_id = ?", @lesson.id).fix_time_order
+    @reservations_cancelonly = Reservation.where("lesson_id = ?", @lesson.id).cancel_only
+    @zooms_sum = Reservation.where("lesson_id = ? and zoom = ?", @lesson.id,true).cancel_exclusion.count
+    @reals_sum = Reservation.where("lesson_id = ? and zoom = ?", @lesson.id,false).cancel_exclusion.count
     @students_add = Student.kanaorder
-    @waiting = Reservation.where(waiting: true).count
+    @waiting = Reservation.where("lesson_id = ? and waiting = ?", @lesson.id, true).count
   end
 
   def update
@@ -138,7 +139,6 @@ class LessonsController < ApplicationController
       lesson.cancel = true
     else
       lesson.cancel = false
-      message = "再開"
     end
     if lesson.save
       if lesson.cancel?
@@ -151,7 +151,7 @@ class LessonsController < ApplicationController
        flash[:success] = "授業を再開しました。"
       end 
     else
-      flash[:danger] = "#{message}登録に失敗しました"
+      flash[:danger] = "登録に失敗しました"
     end
     redirect_to request.referrer
   end

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,10 +1,13 @@
 class NoticesController < ApplicationController
   before_action :set_notice, only: %i(edit show update destroy)
   before_action :set_student
-  before_action:unless_login
+  before_action :unless_login
+  before_action :day_setting, only: %i(index)
   
   def index
     @notices = Notice.paginate(page: params[:page], per_page: 10)
+    @reservations = Reservation.joins(:lesson).where('lessons.meeting_on >=? and reservations.user_id=?',@today,current_user.id).order(meeting_on: "ASC") 
+    @students = Student.where("user_id = ?",current_user.id).where(withdrawal: nil)
   end
   
   def new

--- a/app/controllers/reservation_logs_controller.rb
+++ b/app/controllers/reservation_logs_controller.rb
@@ -8,7 +8,10 @@ class ReservationLogsController < ApplicationController
     else
       @day = Date.today
     end
-    @reservation_logs = Reservation.log_order.where("meeting_on >= ? and meeting_on <= ?", @day.beginning_of_month, @day.end_of_month)
-    @reservation_logs = @reservation_logs.where(user_id: current_user.id) if current_user.admin == false
+    if current_user.admin?
+      @reservation_logs = Reservation.log_order.where("meeting_on >= ? and meeting_on <= ?", @day.beginning_of_month, @day.end_of_month)
+    else
+      @reservation_logs = Reservation.log_order.where("meeting_on >= ? and meeting_on <= ?", @day.beginning_of_month, @day.end_of_month).where(user_id: current_user.id) 
+    end
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -56,8 +56,13 @@ class ReservationsController < ApplicationController
     
     if params[:no] == "6"
         if @reservation.update_attributes(zoom: params[:reservation][:zoom])
-           @reservation.update_attributes(fix_time: params[:reservation][:fix_time])
-          flash[:success] = "固定時間と授業方法を更新しました。"
+          @reservation.update_attributes(fix_time: params[:reservation][:fix_time])
+         
+          send_mail_address
+          title = "授業時間が確定しました"
+          content = "授業時間が確定しました。下記のリンクを確認お願いします。"
+          UserMailer.send_mail( @destination_user, @send_user, title, content, @link).deliver_now
+          flash[:success] = "固定時間と授業方法を更新し、該当ユーザーにメールを送信しました"
         else
           flash[:danger] = "固定時間と授業方法の更新に失敗しました。"
         end
@@ -66,7 +71,11 @@ class ReservationsController < ApplicationController
     
     if params[:no] == "7"
         if @reservation.update_attributes(waiting: false)
-          flash[:success] = "キャンセル待ちを解除して授業枠の登録をしました。"
+          send_mail_address
+          title = "キャンセル待ちを解除して授業枠の登録をしました"
+          content = "キャンセル待ちを解除して授業枠の登録をしました。下記のリンクを確認お願いします。"
+          UserMailer.send_mail( @destination_user, @send_user, title, content, @link).deliver_now
+          flash[:success] = "キャンセル待ちを解除して授業枠の登録をして、該当ユーザーにメールを送信しました"
         else
           flash[:danger] = "キャンセル待ちを解除して授業枠の登録に失敗しました。"
         end
@@ -79,10 +88,16 @@ class ReservationsController < ApplicationController
     @user = User.find_by(params[:id])
   end
   
+  def send_mail_address 
+    @destination_user = User.find( @reservation.user_id )
+    @send_user =  current_user
+    @link = "reservationusers/useredit?reservation_id=#{@reservation.id}&student_id=#{@reservation.student_id}"
+  end
   private
   
   def reservation_params
      params.require(:reservation).permit(:zoom, :fix_time)
   end
+
   
 end

--- a/app/controllers/reservationusers_controller.rb
+++ b/app/controllers/reservationusers_controller.rb
@@ -27,7 +27,7 @@ class ReservationusersController < ApplicationController
     @reservation = Reservation.find(reservation_id)
     @reservation.zoom = @zoom
     @reservation.save
-    @lesson = Lesson.find(@reservation.lesson_id)
+    
     waiting_registration
     if @reservation.save
       flash[:success] = "受講方法を変更しました"
@@ -45,7 +45,7 @@ class ReservationusersController < ApplicationController
     reservationarray = transfer_day_id.split("-")
     @reservation.lesson_id = reservationarray[0].to_i
     @reservation.lesson_id = reservationarray[0].to_i
-    if reservationarray[1]=="1"
+    if reservationarray[1] == "1"
       @reservation.zoom = false
     else
       @reservation.zoom = true
@@ -55,7 +55,6 @@ class ReservationusersController < ApplicationController
     @lesson = Lesson.find(@reservation.lesson_id)
     @lesson_meeting_on = @lesson.meeting_on
     @reservation.save
-    @zoom = @reservation.zoom
     #キャンセル待ち登録
     waiting_registration
     if @reservation.save
@@ -68,25 +67,39 @@ class ReservationusersController < ApplicationController
   end
 
   def reservation_delete
-    reservation_id=params[:reservation_id]
-    reservation=Reservation.find(reservation_id)
-    lesson=Lesson.find(reservation.lesson_id)
-    #予約情報を削除
-    reservation.destroy
-    flash[:danger]="キャンセル登録しました"
-    if current_user.admin?
-      redirect_to "/lessons/#{lesson.id}/lesson_detail"
+    cancel = params[:cancel]
+    reservation_id = params[:reservation_id]
+    @reservation = Reservation.find(reservation_id)
+    if cancel == "true"
+    #予約情報をキャンセル登録
+      @reservation.cancel = true
+    #キャンセル待ちも解除する
+      @reservation.waiting = false
     else
-       redirect_to "/lessons/weeklyschedule?cation=1&changeday=#{lesson.meeting_on.to_s}"
+      @reservation.fix_time = nil
+      @reservation.cancel = false 
     end
+    if @reservation.save and @reservation.cancel?
+      flash[:warning] = "予約取消しました"
+    elsif @reservation.save and @reservation.cancel == false
+      flash[:success] = "予約再開しました"
+      #キャンセル待ち登録
+      waiting_registration
+      if @reservation.save and @reservation.waiting?
+        flash[:warning] = "キャンセル登録になります"
+      end
+    else
+      flash[:danger] = "取消失敗しました"
+    end
+    redirect_to request.referrer
   end
   
   def reservationnewuser
-    @reservation=Reservation.new
-    @student_id=params[:student_id]
-    @student=Student.find(@student_id)
-    @lesson_id=params[:lesson_id]
-    @lesson=Lesson.find(@lesson_id)
+    @reservation = Reservation.new
+    @student_id = params[:student_id]
+    @student = Student.find(@student_id)
+    @lesson_id = params[:lesson_id]
+    @lesson = Lesson.find(@lesson_id)
   end
   
   def reservation_create
@@ -103,15 +116,22 @@ class ReservationusersController < ApplicationController
     #student.cancelnumber=student.cancelnumber-1 if lesson.regular==true
     @reservation = Reservation.new(student_id:student.id,lesson_id:@lesson.id,zoom:zoom,user_id:user_id,fix_time:fix_time)
     @reservation.save
-    @zoom = @reservation.zoom
     waiting_registration
     if @reservation.save
+      message = ""
+      if @reservation.waiting == true
+        message = "キャンセル待ちになりました。"
+        flash[:warning] = "キャンセル待ちになります" if @reservation.waiting == true
+      end
       flash[:success] = "予約登録しました"
-      flash[:warning] = "キャンセル待ちになります" if @reservation.waiting == true
     else
       flash[:danger] = "受講日登録に失敗しました"
     end
     if current_user.admin?
+      send_mail_address
+      title = "授業枠の登録をしました"
+      content = "授業枠の登録をしました。#{message}下記のリンクを確認お願いします。"
+      UserMailer.send_mail( @destination_user, @send_user, title, content, @link).deliver_now
       redirect_to request.referrer
     else
       redirect_to "/reservationusers/useredit?lesson_id=#{@reservation.lesson_id}&student_id=#{student.id}"
@@ -125,8 +145,8 @@ class ReservationusersController < ApplicationController
       @lesson = Lesson.find(@lesson_id)
       @lessons = Lesson.includes(:reservations).all
       @reservation = Reservation.find_by(lesson_id:@lesson.id, student_id:@student.id)
-      @zoomnumber = Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, true).count
-      @realnumber = Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, false).count
+      @zoomnumber = Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, true).cancel_exclusion.count
+      @realnumber = Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, false).cancel_exclusion.count
       @today = Date.today
       @lessoncomment = Lessoncomment.new
       #コメント抽出
@@ -150,14 +170,21 @@ class ReservationusersController < ApplicationController
     end
   end
 
-  def waiting_registration 
-    if @zoom == true and @lesson.seats_zoom < Reservation.where("lesson_id = ? and zoom = ?", @lesson.id, true).count 
+  def waiting_registration
+    @zoom = @reservation.zoom
+    @lesson = Lesson.find(@reservation.lesson_id) 
+    if @zoom == true and @lesson.seats_zoom < Reservation.where("lesson_id = ? and zoom = ?", @lesson.id, true).cancel_exclusion.count 
       @reservation.waiting = true
-    elsif @lesson.seats_real < Reservation.where("lesson_id = ? and zoom = ?", @lesson.id, false).count
+    elsif @lesson.seats_real < Reservation.where("lesson_id = ? and zoom = ?", @lesson.id, false).cancel_exclusion.count
       @reservation.waiting = true
     else 
       @reservation.waiting = false
     end
+  end
+  def send_mail_address 
+    @destination_user = User.find( @reservation.user_id )
+    @send_user =  current_user
+    @link = "reservationusers/useredit?reservation_id=#{@reservation.id}&student_id=#{@reservation.student_id}"
   end
 end
 

--- a/app/helpers/reservations_log_helper.rb
+++ b/app/helpers/reservations_log_helper.rb
@@ -13,6 +13,6 @@ module ReservationsLogHelper
   end
   def log_cancel( cancel ) 
     body = ""
-    body = "【中止】" if cancel == true
+    body = "【授業が中止になりました】" if cancel == true
   end
 end

--- a/app/helpers/reservations_log_helper.rb
+++ b/app/helpers/reservations_log_helper.rb
@@ -1,4 +1,8 @@
 module ReservationsLogHelper
+  def log_personal_cancel( cancel )
+    body = ""
+    body = "予約取消ました" if cancel == true
+  end
   def log_waiting( waiting )
     body = ""
     body = "キャンセル待ちです " if waiting == true

--- a/app/helpers/reservations_log_helper.rb
+++ b/app/helpers/reservations_log_helper.rb
@@ -1,11 +1,11 @@
 module ReservationsLogHelper
   def log_personal_cancel( cancel )
     body = ""
-    body = "予約取消ました" if cancel == true
+    body = "【予約取消しました】" if cancel == true
   end
   def log_waiting( waiting )
     body = ""
-    body = "キャンセル待ちです " if waiting == true
+    body = "【キャンセル待ちです】 " if waiting == true
   end
   def log_transfer( transfer )
     body = ""
@@ -13,10 +13,10 @@ module ReservationsLogHelper
   end
   def log_absence( absence ) 
     body = ""
-    body = "欠席" if absence == true
+    body = "【欠席しました】" if absence == true
   end
   def log_cancel( cancel ) 
     body = ""
-    body = "【授業が中止になりました】" if cancel == true
+    body = "【授業が中止です】" if cancel == true
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,8 +6,10 @@ class UserMailer < ApplicationMailer
     @title = title
     @content = content
     @link = url+link
+    @bcc = "tito40358@gmail.com"
     mail(
       to: destination_user.email,
+      bcc: @bcc,
       subject: title)
   end
   

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -6,5 +6,5 @@ class Lesson < ApplicationRecord
   attr_accessor :starttime
   attr_accessor :finishtime
   attr_accessor :autoregister
-  attr_accessor:fixtimeres
+  attr_accessor :fixtimeres
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -2,8 +2,9 @@ class Reservation < ApplicationRecord
   belongs_to :user
   belongs_to :lesson
   belongs_to :student
-  
-  default_scope -> { order(fix_time: :asc) }
+  scope :fix_time_order , -> { order(fix_time: :asc) }
+  scope :cancel_exclusion, -> { where(cancel: false) }
+  scope :cancel_only, -> { where(cancel: true) }
 
   def self.log_order
     includes(:lesson).order("lessons.meeting_on DESC").order("lessons.started_at DESC")

--- a/app/views/lessons/lesson_detail.html.erb
+++ b/app/views/lessons/lesson_detail.html.erb
@@ -183,6 +183,41 @@
         <% end %>
       <% end %>
 　</table>
+
+<table class="table table-bordered table-condensed" id="table-reservations">
+     <h1 class="modal-title center">【予約取消】</h1>
+     
+      <% if @reservations_cancelonly.present? %>
+           <tr>
+            <th>名前</th>
+            <th>固定時間</th>
+            <th>授業方法</th>
+           </tr>
+      <% else %>
+        <th><h2>予約取消生徒なし</h2></th>
+      <% end %>
+      
+    　<% @reservations_cancelonly.each do |reservation| %>
+        <% if reservation.cancel == true %>
+           <tr>
+            <td>
+              <%= link_to reservation.student.student_name, "/reservationusers/useredit?lesson_id=#{@lesson.id}&student_id=#{reservation.student_id}"  %>
+            </td>
+            <td><%= l(reservation.fix_time, format: :time, default: '-') %></td>
+            <td>
+              <% if reservation.zoom == true %>
+                <span class="label label-info label-user-division">ZOOM</span>
+              <% end %>
+              
+              <% if reservation.zoom == false %>
+                <span class="label label-success label-user-division">リアル</span>
+              <% end %>
+            </td>
+           </tr>
+        <% end %>
+      <% end %>
+　</table>
+
 </div>
 
 <!--モーダルウインドウ表示-->

--- a/app/views/lessons/weeklyschedule.html.erb
+++ b/app/views/lessons/weeklyschedule.html.erb
@@ -138,7 +138,7 @@
             <% tdcolor="#c0ffc0" %>
           <% elsif current_user.admin==true %>
             <% tdcolor="#fffacd" %>
-          <% elsif (lesson.examinee==nil or lesson.examinee==@student.examinee) and lesson.meeting_on.to_date>thisday and (lesson.target==gradesc or lesson.target=="小中学生")  %>
+          <% elsif (lesson.examinee==nil or lesson.examinee==@student.examinee) and lesson.meeting_on.to_date>thisday and (lesson.target==gradesc or lesson.target=="小中高生")  %>
             <% selection=1 %>
             <% if rev.present? and rev.waiting? %>
               <% tdcolor="#fff0f5" %>
@@ -160,11 +160,12 @@
             <%= link_to lesson.target, "/lessons/#{lesson.id}/lesson_detail" %>
           <% elsif rev.present? %>
             <%= link_to lesson.target, {controller: 'reservationusers', action: 'useredit',lesson_id:lesson.id,student_id:@student.id}, {method: :post} %>
-          <% elsif (lesson.examinee==nil or lesson.examinee==@student.examinee) and lesson.meeting_on.to_date>thisday and (lesson.target==gradesc or lesson.target=="小中学生")  %>
+          <% elsif (lesson.examinee==nil or lesson.examinee==@student.examinee) and lesson.meeting_on.to_date>thisday and (lesson.target==gradesc or lesson.target=="小中高生")  %>
             <%= link_to lesson.target, {controller: 'reservationusers', action: 'reservationnewuser',lesson_id:lesson.id,student_id:@student.id}, {method: :post} %>
           <% else %>
             <%= lesson.target %>
           <% end %>
+
           <% if lesson.cancel == true %>
             <span class="label label-danger label-user-division">止</span>
           <% elsif lesson.examinee==true %>

--- a/app/views/lessons/weeklyschedule.html.erb
+++ b/app/views/lessons/weeklyschedule.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, 'ｽｹｼﾞｭｰﾙ表') %>
 <% require 'date' %>
 <% nowtime=Time.new+@timecol  %>
 <% thisday=nowtime.to_date %>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -50,7 +50,7 @@
     </div>
   </div>
   
-    <% @reservations=Reservation.joins(:lesson).where('lessons.meeting_on >=? and reservations.user_id=?',today,current_user.id).order(meeting_on: "ASC")  %>
+    <%  %>
     <% if @reservations.present? %>
     <div class="bg-warning">
     <div class="panel-heading" data-toggle="collapse" data-target="#demo">
@@ -58,9 +58,16 @@
     <div id="demo" class="collapse">
       <% @reservations.each do |reservation| %>
       <br>
-      <% linkname=reservation.lesson.meeting_on %>
       <P>・<%= link_to reservation.lesson.meeting_on,"/reservationusers/useredit?lesson_id=#{reservation.lesson.id}&student_id=#{reservation.student.id}" %>
-        <%=reservation.student.student_name %></P>
+      (<%=weekdate(reservation.lesson.meeting_on) %>)
+      <%= timedisplay(reservation.lesson.started_at) %>～<%= timedisplay(reservation.lesson.finished_at) %>
+      <%= reservation.student.student_name %>&nbsp;&nbsp;
+      <%= log_personal_cancel(reservation.cancel) %>
+           <%= log_waiting(reservation.waiting) %>
+           <%= log_transfer(reservation.transfer) %>
+           <%= log_absence(reservation.absence) %>
+           <%= log_cancel(Lesson.find(reservation.lesson_id).cancel) %>
+      </P>
       <% end %>
     </div>
   </div>
@@ -68,7 +75,6 @@
   <br>
   
   <!-- 2.編集モーダルの配置 -->
-  <% @students=Student.where("user_id = ?",current_user.id).where(withdrawal: nil) %>
   <% if @students.present? %>
 <div class="panel panel-success">
     <div class="panel-heading">

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -1,14 +1,14 @@
 <% provide(:title, 'お知らせ一覧') %>
 <% require 'date' %>
 <% today=Date.today %>
-<h1 style="margin-bottom:-20px;">平川塾からのお知らせ</h1>
+<h1>平川塾からのお知らせ</h1>
 <div class="col-md-8 col-md-offset-2">
-  <div style="margin-bottom:-40px;"><%= will_paginate %></div>
   <div class="add-notice-information-btn">
     <% if current_user.admin? %>
     <%= link_to "お知らせ投稿", new_notice_path, class: "btn btn-primary" %>
     <% end %>
   </div>
+  <% if @notices.present? %>
   <table class="table-bordered table-condensed" id="notices-info">
     <thead>
       <tr>
@@ -32,8 +32,17 @@
       </tr>
       <% end %>
     </thead>
-  </table><br>
-  
+  </table>
+  <% else %>
+    <h2>投稿はありません</h2>
+  <% end %>
+  <% if will_paginate.blank? %>
+    <br>
+  <% else %>
+  <div style = "margin : -20px 0 -20px 0" >
+      <%= will_paginate %>
+  </div>
+  <% end %>
   <div class="panel panel-info">
     <div class="panel-heading">
       <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -49,8 +49,6 @@
       &nbsp;<%= link_to "スケジュールへのリンク", lessons_weeklyschedule_path %>
     </div>
   </div>
-  
-    <%  %>
     <% if @reservations.present? %>
     <div class="bg-warning">
     <div class="panel-heading" data-toggle="collapse" data-target="#demo">

--- a/app/views/reservation_logs/index.html.erb
+++ b/app/views/reservation_logs/index.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, '予約履歴') %>
 <% dateup = @day.end_of_month+1 %>
 <% datedown = @day.beginning_of_month-1 %>
 <h2 class="lead">予約履歴</h2>

--- a/app/views/reservation_logs/index.html.erb
+++ b/app/views/reservation_logs/index.html.erb
@@ -19,7 +19,7 @@
     <thead>
    <% @reservation_logs.each do |log| %>
       <tr>
-        <td><%= daydis(log.lesson.meeting_on) %> ( <%=weekdate(log.lesson.meeting_on) %> )</td>
+        <td><%= log.lesson.meeting_on %> ( <%=weekdate(log.lesson.meeting_on) %> )</td>
         <td>
            <%= timedisplay(log.lesson.started_at) %> ～ <%= timedisplay(log.lesson.finished_at) %>
         </td>
@@ -27,6 +27,7 @@
            <%= link_to log.student.student_name, "/reservationusers/useredit?lesson_id=#{log.lesson.id}&student_id=#{log.student.id}" %>
         </td>
         <td style="text-align: left;">
+           <%= log_personal_cancel(log.cancel) %>
            <%= log_waiting(log.waiting) %>
            <%= log_transfer(log.transfer) %>
            <%= log_absence(log.absence) %>

--- a/app/views/reservation_logs/index.html.erb
+++ b/app/views/reservation_logs/index.html.erb
@@ -7,13 +7,13 @@
 </h2>
 <div class="col-md-10 col-md-offset-1">
 <% if @reservation_logs.present? %>
-  <table class="table-bordered table-condensed" id="reservations-info">
+  <table class="table-bordered table-condensed table table-striped" id="reservations-info">
     <thead>
       <tr>
-        <th  class="col-md-2">授業日</th>
-        <th  class="col-md-2">授業時間</th>
-        <th  class="col-md-3">生徒名</th>
-        <th  class="col-md-3">備考</th>
+        <th  class="col-md-2" style="width:15px;">授業日</th>
+        <th  class="col-md-2" style="width:15px;">授業時間</th>
+        <th  class="col-md-3" style="width:15px;">生徒名</th>
+        <th  class="col-md-3" style="width:25px;">備考</th>
       </tr>
     </thead>
     <thead>

--- a/app/views/reservationusers/_reservation.html.erb
+++ b/app/views/reservationusers/_reservation.html.erb
@@ -19,10 +19,10 @@
     <tr><td class="tdcondition2">授業方法</td>
     <td>
       <% @realseat=@lesson.seats_real %>
-      <% @realnumber=Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, false).count %>
+      <% @realnumber=Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, false).cancel_exclusion.count %>
       <% @zoom=true if @student.zoom? %>
       <% @zoomseat=@lesson.seats_zoom %>
-      <% @zoomnumber=Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, true).count %>
+      <% @zoomnumber=Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, true).cancel_exclusion.count %>
       <%= form_with(url:reservationusers_reservationnewusercreate_path,local: true) do |f| %>
       <% if @zoom? %>
         <%= f.radio_button :zoom, :false %>&nbsp;リアル(<%=@realnumber %>/<%=@realseat %>)

--- a/app/views/reservationusers/_useredit.html.erb
+++ b/app/views/reservationusers/_useredit.html.erb
@@ -10,7 +10,9 @@
     一般
     <% end %>
     コース
-    <% if @reservation.waiting==true %>
+    <% if @reservation.cancel==true %>
+      <span class="label label-danger">予約取は取り消されています</span>
+    <% elsif @reservation.waiting==true %>
       <span class="label label-danger">キャンセル待ち</span>
     <% else %>
       <span class="label label-info">予約済</span>

--- a/app/views/reservationusers/reservationnewuser.html.erb
+++ b/app/views/reservationusers/reservationnewuser.html.erb
@@ -24,10 +24,10 @@
     <tr><td class="tdcondition2">授業方法</td>
     <td>
       <% realseat=@lesson.seats_real %>
-      <% realnumber=Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, false).count %>
+      <% realnumber=Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, false).cancel_exclusion.count %>
       <% zoom=true if @student.zoom? %>
       <% zoomseat=@lesson.seats_zoom %>
-      <% zoomnumber=Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, true).count %>
+      <% zoomnumber=Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, true).cancel_exclusion.count %>
       <%= form_with(url:reservationusers_reservation_create_path,local: true) do |f| %>
       <% if zoom==true %>
         <%= f.radio_button :zoom, :false %>&nbsp;リアル(<%=realnumber %>/<%=realseat %>)

--- a/app/views/reservationusers/useredit.html.erb
+++ b/app/views/reservationusers/useredit.html.erb
@@ -10,7 +10,9 @@
     一般
     <% end %>
     コース
-    <% if @reservation.waiting==true %>
+    <% if @reservation.cancel? %>
+      <span class="label label-danger">予約取消</span>
+    <% elsif @reservation.waiting == true %>
       <span class="label label-danger">キャンセル待ち</span>
     <% else %>
       <span class="label label-info">予約済</span>
@@ -68,11 +70,15 @@
       </div>
       <% end %>
       <div style="display: inline-block;">
-        <%= button_to "授業取消", {controller: 'reservationusers', action: 'reservation_delete'}, {method: :get, data: { confirm: '本当に取消しますか？' }, params: {reservation_id:@reservation.id},class:"btn btn-danger button_size"} %>
+      <% if @reservation.cancel == false %>
+        <%= button_to "授業取消", {controller: 'reservationusers', action: 'reservation_delete'}, {method: :get, data: { confirm: '本当に取消しますか？' }, params: {reservation_id:@reservation.id, cancel:true },class:"btn btn-danger button_size"} %>
+      <% else %>
+        <%= button_to "授業再開", {controller: 'reservationusers', action: 'reservation_delete'}, {method: :get, data: { confirm: '本当に再開しますか？' }, params: {reservation_id:@reservation.id},class:"btn btn-primary button_size"} %>
+      <% end %>
       </div>&nbsp;
     <% end %>
     <div style="display: inline-block;">
-      <%= link_to "ｽｹｼﾞｭｰﾙ" ,"/lessons/weeklyschedule?cation=1&changeday=#{@lesson.meeting_on}",class:"btn btn-info button_size" %>&nbsp;
+      <%= link_to "ｽｹｼﾞｭｰﾙ" ,lessons_weeklyschedule_path, class:"btn btn-info button_size" %>&nbsp;
     </div>
 
     <% if current_user.admin? %>

--- a/db/migrate/20200507190306_add_cancelreservations.rb
+++ b/db/migrate/20200507190306_add_cancelreservations.rb
@@ -1,0 +1,5 @@
+class AddCancelreservations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :reservations, :cancel, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_04_025656) do
+ActiveRecord::Schema.define(version: 2020_05_07_190306) do
 
   create_table "answers", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 2020_05_04_025656) do
     t.boolean "absence", default: false
     t.boolean "transfer", default: false
     t.time "fix_time"
+    t.boolean "cancel", default: false
     t.index ["lesson_id"], name: "index_reservations_on_lesson_id"
     t.index ["user_id"], name: "index_reservations_on_user_id"
   end


### PR DESCRIPTION
〇ユーザ―側予約取消機能修正　
従来は取消時削除していたが、履歴がみれなくなるので予約テーブルにキャンセルカラムを追加して取り消したら削除せず取消登録されように修正した。
・関連している画面（授業管理画面、授業振替機能、キャンセル登録）にデータから取消したデータが抽出やカウントされないようキャンセル登録以外のスコープ作成し、各項目に適用した。
・予約履歴に授業取消表示の機能作成
・管理者用授業管理画面に３段目を作成し、先生が予約取消した生徒を把握できるようした。
・ユーザー側予約登録画面で予約再開機能追加

〇メール実装機能追加
管理者が授業に生徒追加やキャンセル待ち解除、固定時間設定を行うと自動的にメールが生徒に送られるようにした、