### PR TITLE
76_1ユーザーコントローラーメソッド重複解消_edit

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -56,17 +56,15 @@ class StudentsController < ApplicationController
     def student_params
       params.require(:student).permit(:student_name, :user_id, :studentkana,  :zoom, :examinee, :school,  :birthday, :fix_day, :fix_time, :fix_day2, :fix_time2, :fix_day3, :fix_time3, :note, :withdrawal)
     end
-    
-  # beforeフィルター
   
   # ログイン済みのユーザーか確認します。
-  def logged_in_user
-    unless logged_in?
-      store_location
-      flash[:danger] = "ログインしてください。"
-      redirect_to login_url
+    def logged_in_user
+      unless logged_in?
+        store_location
+        flash[:danger] = "ログインしてください。"
+        redirect_to login_url
+      end
     end
-  end
 
   def send_mail_address
     @destination_user = User.find( @student.user_id )

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,14 +43,6 @@ class UsersController < ApplicationController
     
   end
 
-
-  def destroy
-    @user.destroy
-    flash[:success] = "#{@user.student}のデータを削除しました。"
-    redirect_to users_url
-  end
-
-  
   def update
     if @user.update_attributes(user_params)
       flash[:success] = "情報を更新しました。"
@@ -59,7 +51,6 @@ class UsersController < ApplicationController
       render :edit      
     end
     @user = User.find(params[:id])
-
   end
   
   def destroy

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -54,13 +54,11 @@ class UsersController < ApplicationController
   end
   
   def destroy
-    @user.destroy
-    students = Student.where(user_id:@user.id)
-    students.each do |student|
-      reservation = Reservation.where(student_id:student.id)
-      reservation.destroy
+    if @user.destroy
+      flash[:success] = "#{@user.guardian}のデータを削除しました。"
+    else
+      flash[:danger] = "#{@user.guardian}のデータ削除に失敗しました。"
     end
-    flash[:success] = "#{@user.guardian}のデータを削除しました。"
     redirect_to users_url
   end
   

--- a/app/views/notices/_notice_form.html.erb
+++ b/app/views/notices/_notice_form.html.erb
@@ -7,6 +7,10 @@
   <%= f.label :notice_content, class: "label-#{yield(:class_text)}" %>
   <%= f.text_area :notice_content, class: "form-control", rows: 10 %>
   
-  <%= f.submit yield(:button_text), class: "btn btn-primary btn-block btn-#{yield(:class_text)}" %>
-  
+  <%= f.submit yield(:button_text), class: "btn btn-primary btn-block btn-#{yield(:class_text)}" %><br />
+  <p style="text-align:center"><a href="#" onclick="javascript:window.history.back(-1);return false;">詳細に戻る</a></p>
+  <br />
+  <% if current_user.admin? %>
+    <p style="text-align:center"><a href="http://titonet384.sakura.ne.jp/linkmake/"  target="_blank">リンクはこちらでタグ作成して貼り付けて下さい</a></p>
+  <% end %>
 <% end %>

--- a/app/views/notices/edit.html.erb
+++ b/app/views/notices/edit.html.erb
@@ -2,14 +2,9 @@
 <% provide(:class_text, 'signup') %>
 <% provide(:button_text, 'お知らせ投稿編集') %>
 <h1>お知らせ詳細</h1>
-
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= render 'notice_form' %>
   </div>
 </div>
-<br />
-<p style="text-align:center"><a href="#" onclick="javascript:window.history.back(-1);return false;">詳細に戻る</a></p>
-<% if current_user.admin? %>
-    <p style="text-align:center"><a href="http://titonet384.sakura.ne.jp/linkmake/"  target="_blank">リンクはこちらで作成して貼り付けて下さい</a></p>
-<% end %>
+

--- a/app/views/notices/new.html.erb
+++ b/app/views/notices/new.html.erb
@@ -2,7 +2,6 @@
 <% provide(:class_text, 'signup') %>
 <% provide(:button_text, 'お知らせ投稿') %>
 <h1>お知らせ情報登録</h1>
-
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= render 'notice_form' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_with(model: @user, local: true) do |f| %>
+    <%= form_with(model: @user, local: true, method: :put) do |f| %>
     
       ・<%= f.label :保護者名前, class: "label-signup" %>
       <span class="label label-danger label-user-division">必須</span>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -33,7 +33,7 @@
           <span class="label label-success label-user-division">一般</span>
         </td>
         <td>
-        <%= link_to "削除", user_path(user.id), method: :delete, 
+        <%= link_to "削除","users/#{user.id}/delete", method: :delete, 
               data:  { confirm: "本当に削除してよろしいですか？該当の受講生、予約授業も併せて削除します"},
               class: "btn btn-danger btn-sm" %>
           <% students = @students.where(user_id: user.id) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
-
+  
+  #個人情報保護ページ
   get 'protection_low/index'
   #　レッスン関連
   get 'lessons/weeklyschedule'
@@ -7,8 +8,6 @@ Rails.application.routes.draw do
   #　ユーザー側予約詳細へ
   post 'reservationusers/useredit', to: 'reservationusers#useredit'
   get 'reservationusers/useredit', to: 'reservationusers#useredit'
-  post 'reservationusers/usermail', to: 'reservationusers#usermail'
-  get 'reservationusers/usermail', to: 'reservationusers#usermail'
   #　ユーザー側予約情報更新
   post 'reservationusers/userupdate', to: 'reservationusers#userupdate'
   get 'reservationusers/reservation_delete', to: 'reservationusers#reservation_delete'
@@ -32,9 +31,6 @@ Rails.application.routes.draw do
   post   '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
   
-  #個人情報保護ページ
-  get 'protection_law/index'
-
   resources :reservation_logs, only: [:index]
   
   # ログインボタン(管理者、生徒)
@@ -43,13 +39,13 @@ Rails.application.routes.draw do
   
   resources :users do
     member do
+      put 'update'
       get 'edit_basic_info'
       patch 'update_basic_info'
       get 'edit'
-      delete 'destroy'
-      patch 'update'
     end
   end
+  delete 'users/:id/delete', to: 'users#destroy'
   
   resources :lessons do
    member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,10 +39,10 @@ Rails.application.routes.draw do
   
   resources :users do
     member do
-      put 'update'
       get 'edit_basic_info'
       patch 'update_basic_info'
       get 'edit'
+      put 'update'
     end
   end
   delete 'users/:id/delete', to: 'users#destroy'
@@ -72,13 +72,11 @@ Rails.application.routes.draw do
     end
   end
 
- 
   resources :notices
   
   resources :reservations, only: [:update, :destroy]
-  resources :questions
   
-  resources :password_resets, only: [:new, :create, :edit, :update]
+  resources :questions
   
   resources :password_resets, only: [:new, :create, :edit, :update]
 end


### PR DESCRIPTION
・ユーザーコントローラー重複解消
・同上でユーザー削除時　生徒　予約の削除
・ユーザー削除のルーティングをresouces外で設定
（deleteとupdateの併用ができないため　railsの不具合と推測される）
・routesの重複あり１つ削除　個人情報、password_resetsのresouces
・notice タグリンク挿入可能につき、タグ作成補助サイトへのリンク表示