### PR TITLE
79_1生徒固定時間一覧表モーダル修正_edit

### DIFF
--- a/app/views/reservation_logs/index.html.erb
+++ b/app/views/reservation_logs/index.html.erb
@@ -17,7 +17,7 @@
         <th style="width:100px;">授業時間</th>
         <th style="width:60px;">固定時間</th>
         <th style="width:130px;">生徒名</th>
-        <th style="width:60px;">コメント</th>
+        <th style="width:40px;">コメント</th>
         <th style="width:25px;">出席</th>
         <th style="width:160px;">備考</th>
       </tr>

--- a/app/views/reservation_logs/index.html.erb
+++ b/app/views/reservation_logs/index.html.erb
@@ -46,12 +46,12 @@
         </td>
         <td style="text-align: center;">
            <%= "済" if log.attendance_time != nil %>
+           <%= "欠席" if log.absence? %>
         </td>
         <td style="text-align: left;">
            <%= log_personal_cancel(log.cancel) %>
            <%= log_waiting(log.waiting) %>
            <%= log_transfer(log.transfer) %>
-           <%= log_absence(log.absence) %>
            <%= log_cancel(Lesson.find(log.lesson_id).cancel) %>
         </td>
       </tr>


### PR DESCRIPTION
予約履歴に出席済のカラム追加
契約一覧のモーダルリストに受験生、ZOOM受講の表示追加
予約振替のメソッドに不具合があったため修正
・・・予約取消から振替とそのまま予約取消になるので取消を自動で解除する