### PR TITLE
81_1受講生基本情報修正_edit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,6 @@ class ApplicationController < ActionController::Base
   end
   
   def fix_check
-    @student = Student.find(student_params[:id])
     @studentcheck = Student.new(student_params)
       @fix_check = 0
       if ( @studentcheck.fix_day2 != "" and @studentcheck.fix_time2 == nil ) or ( @studentcheck.fix_day2 == "" and @studentcheck.fix_time2 != nil )

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,4 +69,17 @@ class ApplicationController < ActionController::Base
     host = request.host
     @url = "#{ protocol }#{ host }/" #現在のurlを取得
   end
+  
+  def fix_check
+    @student = Student.find(student_params[:id])
+    @studentcheck = Student.new(student_params)
+      @fix_check = 0
+      if ( @studentcheck.fix_day2 != "" and @studentcheck.fix_time2 == nil ) or ( @studentcheck.fix_day2 == "" and @studentcheck.fix_time2 != nil )
+        @fix_check = 1
+      elsif ( @studentcheck.fix_day3 != "" and @studentcheck.fix_time3 == nil ) or ( @studentcheck.fix_day3 == "" and @studentcheck.fix_time3 != nil )
+       @fix_check = 1
+      elsif ( @studentcheck.fix_day4 != "" and @studentcheck.fix_time4 == nil ) or ( @studentcheck.fix_day4 == "" and @studentcheck.fix_time4 != nil )
+       @fix_check = 1
+      end
+  end
 end

--- a/app/controllers/maneger_students_controller.rb
+++ b/app/controllers/maneger_students_controller.rb
@@ -1,10 +1,9 @@
 class ManegerStudentsController < ApplicationController
+  before_action :fix_check,   only: [:update]
+  
   def update
     @lesson = Lesson.find(lesson_params[:id])
     @lesson.note = lesson_params[:note]
-    @student = Student.find(student_params[:id])
-    @studentcheck = Student.new(student_params)
-    fix_check
     if @fix_check == 1
       flash[:danger] = "#{@student.student_name}の更新は失敗しました。"
     elsif @student.update(student_params) && @lesson.save
@@ -22,14 +21,5 @@ class ManegerStudentsController < ApplicationController
   def lesson_params
      params.require(:lesson).permit( :id, :note)
   end
-  def fix_check
-      @fix_check = 0
-      if ( @studentcheck.fix_day2 != "" and @studentcheck.fix_time2 == nil ) or ( @studentcheck.fix_day2 == "" and @studentcheck.fix_time2 != nil )
-        @fix_check = 1
-      elsif ( @studentcheck.fix_day3 != "" and @studentcheck.fix_time3 == nil ) or ( @studentcheck.fix_day3 == "" and @studentcheck.fix_time3 != nil )
-       @fix_check = 1
-      elsif ( @studentcheck.fix_day4 != "" and @studentcheck.fix_time4 == nil ) or ( @studentcheck.fix_day4 == "" and @studentcheck.fix_time4 != nil )
-       @fix_check = 1
-      end
-    end
+  
 end

--- a/app/controllers/maneger_students_controller.rb
+++ b/app/controllers/maneger_students_controller.rb
@@ -2,10 +2,11 @@ class ManegerStudentsController < ApplicationController
   before_action :fix_check,   only: [:update]
   
   def update
+    @student = Student.find(student_params[:id])
     @lesson = Lesson.find(lesson_params[:id])
     @lesson.note = lesson_params[:note]
     if @fix_check == 1
-      flash[:danger] = "#{@student.student_name}の更新は失敗しました。"
+      flash[:danger] = "更新は失敗しました。"
     elsif @student.update(student_params) && @lesson.save
       flash[:success] = "更新に成功しました"
     else

--- a/app/controllers/maneger_students_controller.rb
+++ b/app/controllers/maneger_students_controller.rb
@@ -11,7 +11,7 @@ class ManegerStudentsController < ApplicationController
     else
       flash[:warning] = "更新に失敗しました"
     end
-      redirect_to request.referrer
+    redirect_to request.referrer
   end
 
   private

--- a/app/controllers/maneger_students_controller.rb
+++ b/app/controllers/maneger_students_controller.rb
@@ -3,7 +3,11 @@ class ManegerStudentsController < ApplicationController
     @lesson = Lesson.find(lesson_params[:id])
     @lesson.note = lesson_params[:note]
     @student = Student.find(student_params[:id])
-    if @student.update(student_params) && @lesson.save
+    @studentcheck = Student.new(student_params)
+    fix_check
+    if @fix_check == 1
+      flash[:danger] = "#{@student.student_name}の更新は失敗しました。"
+    elsif @student.update(student_params) && @lesson.save
       flash[:success] = "更新に成功しました"
     else
       flash[:warning] = "更新に失敗しました"
@@ -13,9 +17,19 @@ class ManegerStudentsController < ApplicationController
 
   private
   def student_params
-     params.require(:student).permit( :id, :school, :zoom, :examinee, :fix_day, :fix_time, :fix_day2, :fix_time2, :fix_day3, :fix_time3, :note)
+     params.require(:student).permit( :id, :school, :zoom, :examinee, :fix_day, :fix_time, :fix_day2, :fix_time2, :fix_day3, :fix_time3, :fix_day4, :fix_time4, :note)
   end
   def lesson_params
      params.require(:lesson).permit( :id, :note)
   end
+  def fix_check
+      @fix_check = 0
+      if ( @studentcheck.fix_day2 != "" and @studentcheck.fix_time2 == nil ) or ( @studentcheck.fix_day2 == "" and @studentcheck.fix_time2 != nil )
+        @fix_check = 1
+      elsif ( @studentcheck.fix_day3 != "" and @studentcheck.fix_time3 == nil ) or ( @studentcheck.fix_day3 == "" and @studentcheck.fix_time3 != nil )
+       @fix_check = 1
+      elsif ( @studentcheck.fix_day4 != "" and @studentcheck.fix_time4 == nil ) or ( @studentcheck.fix_day4 == "" and @studentcheck.fix_time4 != nil )
+       @fix_check = 1
+      end
+    end
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -3,6 +3,7 @@ class StudentsController < ApplicationController
   before_action :logged_in_user, only: [:show, :info_edit, :info_update]
   before_action :day_setting, only: [:info_update]
   before_action :mail_link_host,   only: [:create]
+  before_action :fix_check,   only: [:info_update,:create]
   
   def show
     @students = Student.all
@@ -12,9 +13,6 @@ class StudentsController < ApplicationController
   end
   
   def info_update
-    
-    @studentcheck = Student.new(student_params)
-    fix_check
     if @fix_check == 1
       flash[:danger] = "#{@student.student_name}の更新は失敗しました。"
     elsif @student.update_attributes(student_params)
@@ -34,9 +32,7 @@ class StudentsController < ApplicationController
   end
 
   def create
-     @studentcheck = Student.new(student_params)
-     @student = @studentcheck
-     fix_check
+     @student = Student.new(student_params)
      if @fix_check == 1
        flash[:danger] = "固定時間の入力に不正あり登録に失敗しました。"
      elsif @student.save
@@ -85,16 +81,5 @@ class StudentsController < ApplicationController
       link = "notices"
       @link = @url + link
       UserMailer.send_mail( @destination_user, @send_user, @bcc, @title, @content,@link).deliver_now
-    end
-    
-    def fix_check
-      @fix_check = 0
-      if ( @studentcheck.fix_day2 != "" and @studentcheck.fix_time2 == nil ) or ( @studentcheck.fix_day2 == "" and @studentcheck.fix_time2 != nil )
-        @fix_check = 1
-      elsif ( @studentcheck.fix_day3 != "" and @studentcheck.fix_time3 == nil ) or ( @studentcheck.fix_day3 == "" and @studentcheck.fix_time3 != nil )
-       @fix_check = 1
-      elsif ( @studentcheck.fix_day4 != "" and @studentcheck.fix_time4 == nil ) or ( @studentcheck.fix_day4 == "" and @studentcheck.fix_time4 != nil )
-       @fix_check = 1
-      end
     end
 end

--- a/app/views/notices/_basicstudent.html.erb
+++ b/app/views/notices/_basicstudent.html.erb
@@ -35,7 +35,7 @@
                       <%= student.fix_time.hour %>:<%= mindisplay(student.fix_time) %>～
                     </td>
                   </tr>
-                  <% if student.fix_day2.present? %>
+                  <% if student.fix_day2.present? and student.fix_time2.present? %>
                     <tr>
                       <th>固定時間2</th>
                       <td>
@@ -44,7 +44,7 @@
                       </td>
                     </tr>
                     <% end %>
-                      <% if student.fix_day3.present? %>
+                      <% if student.fix_day3.present? and student.fix_time3.present? %>
                         <tr>
                           <th>固定時間3</th>
                           <td>
@@ -53,7 +53,7 @@
                           </td>
                         </tr>
                         <% end %>
-                        <% if student.fix_day4.present? %>
+                        <% if student.fix_day4.present? and student.fix_time4.present? %>
                         <tr>
                           <th>固定時間4</th>
                           <td>

--- a/app/views/notices/_basicstudent.html.erb
+++ b/app/views/notices/_basicstudent.html.erb
@@ -58,7 +58,7 @@
                           <th>固定時間4</th>
                           <td>
                             <%= student.fix_day4 %>曜日
-                            <%= student.fix_time4.hour %>:<%= mindisplay(student.fix_time3) %>～
+                            <%= student.fix_time4.hour %>:<%= mindisplay(student.fix_time4) %>～
                           </td>
                         </tr>
                         <% end %>

--- a/app/views/reservationusers/_student.html.erb
+++ b/app/views/reservationusers/_student.html.erb
@@ -51,7 +51,7 @@
       <label for="text5">生徒基本固定時間3:</label>
       <%= f.time_field :fix_time3 , class: "form-control" %>
       <label for="text4">生徒基本固定曜日4:</label>
-      <%= f.select :fix_day3, @weekday, { include_blank: true,selected:@student.fix_day4 }, class: "form-control" %>
+      <%= f.select :fix_day4, @weekday, { include_blank: true,selected:@student.fix_day4 }, class: "form-control" %>
       <label for="text5">生徒基本固定時間4:</label>
       <%= f.time_field :fix_time4 , class: "form-control" %>
       <div class="modal-footer">

--- a/app/views/reservationusers/_student.html.erb
+++ b/app/views/reservationusers/_student.html.erb
@@ -50,6 +50,10 @@
       <%= f.select :fix_day3, @weekday, { include_blank: true,selected:@student.fix_day3 }, class: "form-control" %>
       <label for="text5">生徒基本固定時間3:</label>
       <%= f.time_field :fix_time3 , class: "form-control" %>
+      <label for="text4">生徒基本固定曜日4:</label>
+      <%= f.select :fix_day3, @weekday, { include_blank: true,selected:@student.fix_day4 }, class: "form-control" %>
+      <label for="text5">生徒基本固定時間4:</label>
+      <%= f.time_field :fix_time4 , class: "form-control" %>
       <div class="modal-footer">
         <%= f.submit "登録", class: "btn btn-primary" %>
       <% end %>&nbsp;

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -45,18 +45,21 @@
             (<%= Student.gradeyear(student.id) %> <%= student.school %>)
             <% if student.withdrawal.blank? %>
                 固定時間1:<%= student.fix_day %> <%= timedisplay(student.fix_time) %>
-              <% if student.fix_day2.present? %>
+            <% if student.fix_day2.present? %>
                 固定時間2:<%= student.fix_day2 %> <%= timedisplay(student.fix_time2) %>
-              <% end %>
-              <% if student.fix_day3.present? %>
+            <% end %>
+            <% if student.fix_day3.present? %>
                 固定時間3:<%= student.fix_day3 %> <%= timedisplay(student.fix_time3) %>
-              <% end %>
-              <% if student.fix_day4.present? %>
+            <% end %>
+            <% if student.fix_day4.present? %>
                 固定時間4:<%= student.fix_day4 %> <%= timedisplay(student.fix_time4) %>
-              <% end %>
-              <% if student.examinee? %>
+            <% end %>
+            <% if student.zoom?  %>
+              <span class="label label-warning label-user-division">zoom</span>
+            <% end %>
+            <% if student.examinee? %>
                 <span class="label label-success label-user-division">受験生</span>
-              <% end %>
+            <% end %>
             <% elsif student.withdrawal >=@today%>
                 <span class="label label-warning label-user-division">退会予定</span>
             <% else %>


### PR DESCRIPTION
トップ画面の基本情報閲覧の固定時間４の参照先が誤っていたため修正のプルリクです。
管理者でログイン時、授業詳細の情報修正モーダルに固定時間４の設定追加（前回漏れ）
併せて固定時間２～４　固定時間と曜日のセットいずれか抜けていたら登録や更新できないようにした