### PR TITLE
82_4予約履歴見た目修正等_edi #126

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,6 +24,11 @@
   margin: auto;
 }
 
+.wrapper_normal2 {
+  width: 95%;
+  margin: auto;
+}
+
 @media screen and (max-width:1200px){
 
 .wrapper_normal { 
@@ -42,11 +47,6 @@
   width: 100%;
   margin: auto;
   }
-}
-
-.wrapper_middle {
-  width: 90%;
-  margin: auto;
 }
 
 @media screen and (max-width:1200px){

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -25,13 +25,18 @@
 }
 
 .wrapper_normal2 {
-  width: 95%;
+  width: 80%;
   margin: auto;
 }
 
 @media screen and (max-width:1200px){
 
 .wrapper_normal { 
+  width: 100%;
+  margin: auto;
+  }
+
+.wrapper_normal2 { 
   width: 100%;
   margin: auto;
   }

--- a/app/assets/stylesheets/lessons.css
+++ b/app/assets/stylesheets/lessons.css
@@ -26,7 +26,7 @@
 
 /* 予約詳細画面レスポンシブ設定 */
 .warapper_lesson_detail {
-  width: 90%;
+  width: 70%;
   margin: auto;
 }
 

--- a/app/assets/stylesheets/lessons.css
+++ b/app/assets/stylesheets/lessons.css
@@ -26,7 +26,7 @@
 
 /* 予約詳細画面レスポンシブ設定 */
 .warapper_lesson_detail {
-  width: 70%;
+  width: 80%;
   margin: auto;
 }
 

--- a/app/assets/stylesheets/lessons.css
+++ b/app/assets/stylesheets/lessons.css
@@ -26,7 +26,7 @@
 
 /* 予約詳細画面レスポンシブ設定 */
 .warapper_lesson_detail {
-  width: 80%;
+  width: 75%;
   margin: auto;
 }
 
@@ -67,4 +67,11 @@
   width: 100%;
   margin: auto;
   }
+}
+
+.h1_font_size{
+  font-size:35px;
+}
+.h1_top_margin {
+  margin-top: -5px;
 }

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -59,7 +59,7 @@ class ReservationsController < ApplicationController
         if @reservation.update_attributes(zoom: params[:reservation][:zoom])
           @reservation.update_attributes(fix_time: params[:reservation][:fix_time])
           @title = "授業時間が確定しました"
-          @content = "授業時間が確定しました。下記のリンクを確認お願いします。"
+          @content = "授業時間が確定しました。"
           send_mail_address
           flash[:success] = "固定時間と授業方法を更新し、該当ユーザーにメールを送信しました"
         else

--- a/app/controllers/reservationusers_controller.rb
+++ b/app/controllers/reservationusers_controller.rb
@@ -122,6 +122,8 @@ class ReservationusersController < ApplicationController
     @zoom=true if @student.zoom?
     @zoomseat=@lesson.seats_zoom
     @zoomnumber=Reservation.where(" lesson_id=? AND zoom  = ?" ,@lesson.id, true).cancel_exclusion.count
+    @real_rest_sheet = @realseat - @realnumber
+    @zoom_rest_sheet = @zoomseat - @zoomnumber
   end
   
   def reservation_create
@@ -188,32 +190,32 @@ class ReservationusersController < ApplicationController
         content = capacity + l(les.meeting_on.to_datetime, format: :day_week) + l(les.started_at, format: :time)+"～"+l(les.finished_at, format: :time) + "ZOOM"
         @lessonlists << Listcollection.new(les.id.to_s+"-2",content,true)
       end
+      end
     end
-  end
 
-  def waiting_registration
-    @zoom = @reservation.zoom
-    @lesson = Lesson.find(@reservation.lesson_id) 
-    if @zoom == true and @lesson.seats_zoom < Reservation.where("lesson_id = ? and zoom = ?", @lesson.id, true).cancel_exclusion.count 
-      @reservation.waiting = true
-    elsif @lesson.seats_real < Reservation.where("lesson_id = ? and zoom = ?", @lesson.id, false).cancel_exclusion.count
-      @reservation.waiting = true
-    else 
-      @reservation.waiting = false
+    def waiting_registration
+      @zoom = @reservation.zoom
+      @lesson = Lesson.find(@reservation.lesson_id) 
+      if @zoom == true and @lesson.seats_zoom < Reservation.where("lesson_id = ? and zoom = ?", @lesson.id, true).cancel_exclusion.count 
+        @reservation.waiting = true
+      elsif @lesson.seats_real < Reservation.where("lesson_id = ? and zoom = ?", @lesson.id, false).cancel_exclusion.count
+        @reservation.waiting = true
+      else 
+        @reservation.waiting = false
+      end
     end
-  end
   
-  def send_mail_address
-    if current_user.admin?
-      @destination_user = User.find( @reservation.user_id )
-      @bcc = current_user.email
-    else
-      @destination_user = User.find(1)
-      @bcc = ""
+    def send_mail_address
+      if current_user.admin?
+        @destination_user = User.find( @reservation.user_id )
+        @bcc = current_user.email
+      else
+        @destination_user = User.find(1)
+        @bcc = ""
+      end
+      @send_user =  current_user
+      link = "reservationusers/useredit?reservation_id=#{@reservation.id}&student_id=#{@reservation.student_id}"
+      @link = @url + link
+      UserMailer.send_mail( @destination_user, @send_user, @bcc, @title, @content,@link).deliver_now
     end
-    @send_user =  current_user
-    link = "reservationusers/useredit?reservation_id=#{@reservation.id}&student_id=#{@reservation.student_id}"
-    @link = @url + link
-    UserMailer.send_mail( @destination_user, @send_user, @bcc, @title, @content,@link).deliver_now
-  end
 end

--- a/app/controllers/reservationusers_controller.rb
+++ b/app/controllers/reservationusers_controller.rb
@@ -147,7 +147,7 @@ class ReservationusersController < ApplicationController
         flash[:warning] = "キャンセル待ちになります。" if @reservation.waiting == true
       end
       @title = "予約追加登録"
-      @content = "予約の追加登録をしました。#{message}下記のリンクを確認お願いします。"
+      @content = "予約の追加登録をしました。#{message}"
       send_mail_address
     else
       flash[:danger] = "受講日登録に失敗しました"

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ' 平川塾 <noreply@example.com>'
+  default from: ' 平川塾 <noreply@email.com>'
   layout 'mailer'
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -8,6 +8,6 @@ class Reservation < ApplicationRecord
   scope :waiting_exclusion, -> { where(waiting: false) }
   scope :waiting_only, -> { where(waiting: true) }
   def self.log_order
-    includes(:lesson).order("lessons.meeting_on DESC").order("lessons.started_at DESC")
+    includes(:lesson).order("lessons.meeting_on asc").order("lessons.started_at asc").order("fix_time asc")
   end
 end

--- a/app/views/lessons/lesson_detail.html.erb
+++ b/app/views/lessons/lesson_detail.html.erb
@@ -76,7 +76,7 @@
      <% if @reservations.present? == true %>
          <tr>
            <th style = "width:150px;">名前</th>
-           <th style = "width:50px;">振替</th>
+           <th style = "width:50px;"><div style="white-space:nowrap;">振替</div></th>
            <th style = "width:50px;">固定時間</th>
            <th style = "width:100px;">授業方法</th>
            <th style = "width:50px;">修正</th>

--- a/app/views/lessons/lesson_detail.html.erb
+++ b/app/views/lessons/lesson_detail.html.erb
@@ -20,6 +20,9 @@
     <div style="display: inline-block;">
       <%= button_to "授業削除", {controller: 'lessons', action: 'destroy'}, {method: :delete, data: { confirm: '本当に削除しますか？' }, params: {id: @lesson.id },class:"btn btn-danger button_size"} %>
     </div>
+    <div style="display: inline-block;">
+      <%= link_to "ｽｹｼﾞｭｰﾙ" ,"/lessons/weeklyschedule?cation=1&changeday=#{@lesson.meeting_on}",class:"btn btn-info button_size" %>&nbsp
+    </div>
   </p>
   </div>
 

--- a/app/views/lessons/lesson_detail.html.erb
+++ b/app/views/lessons/lesson_detail.html.erb
@@ -1,7 +1,7 @@
 <% require "date" %>
 <% provide(:title, '予約状況') %>
 
-<h1>【予約詳細】</h1>
+<h1 class = "h1_font_size">【予約詳細】</h1>
 <div class="warapper_lesson_detail">
   <div class="lesson-discontinuation-fix-btn">
   <p>
@@ -71,7 +71,7 @@
   </table>
 
 　<table class="table table-bordered table-condensed" id="table-reservations">
-     <h1 class="modal-title center">【予約生徒・修正&出欠管理】</h1>
+     <h1 class = "h1_font_size">【予約生徒・修正&出欠管理】</h1>
 
      <% if @reservations.present? == true %>
          <tr>
@@ -80,9 +80,9 @@
            <th style = "width:50px;">固定時間</th>
            <th style = "width:100px;">授業方法</th>
            <th style = "width:50px;">修正</th>
-           <th style = "width:80px;">出席</th>
-           <th style = "width:80px;">退席</th>
-           <th style = "width:50px;">欠席</th>
+           <th style = "width:80px;"> <div style="white-space:nowrap;">出席</div></th>
+           <th style = "width:80px;"> <div style="white-space:nowrap;">退席</div></th>
+           <th style = "width:50px;"> <div style="white-space:nowrap;">欠席</div></th>
            <th style = "width:100px;">出欠管理</th>
          </tr>
       <% else %>
@@ -158,7 +158,7 @@
 　</table>
 　　　　　　
 　<table class="table table-bordered table-condensed" id="table-reservations">
-     <h1 class="modal-title center">【キャンセル待ち】</h1>
+     <h1 class = "h1_font_size h1_top_margin">【キャンセル待ち】</h1>
      
       <% if @waiting != 0 %>
            <tr>
@@ -201,7 +201,7 @@
 　</table>
 
 <table class="table table-bordered table-condensed" id="table-reservations">
-     <h1 class="modal-title center">【予約取消】</h1>
+     <h1 class = "h1_font_size h1_top_margin">【予約取消】</h1>
      
       <% if @reservations_cancelonly.present? %>
            <tr>

--- a/app/views/lessons/lesson_detail.html.erb
+++ b/app/views/lessons/lesson_detail.html.erb
@@ -168,8 +168,10 @@
         <% if reservation.waiting == true %>
            <tr>
             <td style="text-align:left;">
+            <div style="white-space:nowrap;">
               <%= link_to reservation.student.student_name, "/reservationusers/useredit?lesson_id=#{@lesson.id}&student_id=#{reservation.student_id}"  %>
               (<%= Student.gradeyear(reservation.student_id) %>)
+            </div>
             </td>
             <td><%= l(reservation.fix_time, format: :time, default: '-') %></td>
             <td>

--- a/app/views/lessons/lesson_detail.html.erb
+++ b/app/views/lessons/lesson_detail.html.erb
@@ -22,10 +22,10 @@
       <%= button_to "授業削除", {controller: 'lessons', action: 'destroy'}, {method: :delete, data: { confirm: '本当に削除しますか？' }, params: {id: @lesson.id },class:"btn btn-danger button_size"} %>
     </div>
     <div style="display: inline-block;">
-      <%= link_to "ｽｹｼﾞｭｰﾙ" ,"/lessons/weeklyschedule?cation=1&changeday=#{@lesson.meeting_on}",class:"btn btn-info button_size" %>&nbsp
+      <%= link_to "ｽｹｼﾞｭｰﾙ" ,"/lessons/weeklyschedule?cation=1&changeday=#{@lesson.meeting_on}",class:"btn btn-info button_size" %>
     </div>
     <div style="display: inline-block;">
-      <%= link_to "予約履歴" ,"/reservation_logs?cation=1&changeday=#{@lesson.meeting_on.beginning_of_month}",class:"btn btn-warning button_size" %>&nbsp
+      <%= link_to "予約履歴" ,"/reservation_logs?cation=1&changeday=#{@lesson.meeting_on.beginning_of_month}",class:"btn btn-warning button_size" %>
     </div>
   </p>
   </div>

--- a/app/views/lessons/lesson_detail.html.erb
+++ b/app/views/lessons/lesson_detail.html.erb
@@ -73,8 +73,8 @@
            <th style = "width:50px;">固定時間</th>
            <th style = "width:100px;">授業方法</th>
            <th style = "width:50px;">修正</th>
-           <th style = "width:80px;">出席時間</th>
-           <th style = "width:80px;">退席時間</th>
+           <th style = "width:80px;">出席</th>
+           <th style = "width:80px;">退席</th>
            <th style = "width:50px;">欠席</th>
            <th style = "width:100px;">出欠管理</th>
          </tr>
@@ -86,9 +86,11 @@
         <% if reservation.waiting == false %>
            <tr>
             <td colspa="3" style="text-align:left;">
+              <div style="white-space:nowrap;">
               <%= link_to reservation.student.student_name,
               "/reservationusers/useredit?lesson_id=#{@lesson.id}&student_id=#{reservation.student_id}"  %>
               (<%= Student.gradeyear(reservation.student_id) %>）
+              </div>
             </td>
             <td>
               <% if reservation.transfer == true %>
@@ -117,6 +119,7 @@
               <% end %>
             </td>
             <td>
+              <div style="white-space:nowrap;">
               <% if reservation.attendance_time.nil? && reservation.absence == false %>
                 <%= link_to "出席", reservation_path(reservation, no: 1), method: :patch, class: "btn btn-primary btn-sm" %>
               <% end %>
@@ -140,6 +143,7 @@
                   data: { confirm: "欠席登録を解除してもよろしいですか？" },
                   class: "btn btn-primary btn-sm" %>
               <% end %>
+              </div>
             </td>
            </tr>
         <% end %>

--- a/app/views/lessons/lesson_detail.html.erb
+++ b/app/views/lessons/lesson_detail.html.erb
@@ -1,3 +1,4 @@
+<% require "date" %>
 <% provide(:title, '予約状況') %>
 
 <h1>【予約詳細】</h1>
@@ -22,6 +23,9 @@
     </div>
     <div style="display: inline-block;">
       <%= link_to "ｽｹｼﾞｭｰﾙ" ,"/lessons/weeklyschedule?cation=1&changeday=#{@lesson.meeting_on}",class:"btn btn-info button_size" %>&nbsp
+    </div>
+    <div style="display: inline-block;">
+      <%= link_to "予約履歴" ,"/reservation_logs?cation=1&changeday=#{@lesson.meeting_on.beginning_of_month}",class:"btn btn-warning button_size" %>&nbsp
     </div>
   </p>
   </div>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -51,7 +51,7 @@
     <% if @reservations.present? %>
     <div class="bg-warning">
     <div class="panel-heading" data-toggle="collapse" data-target="#demo">
-      <span class="glyphicon glyphicon-envelope" aria-hidden="true"> 予約確認・コメント（クリックで展開）</div></span>
+      <span class="glyphicon glyphicon-envelope" aria-hidden="true"> 予約確認・予約授業へのコメント（遅刻等の連絡、クリックで展開）</div></span>
     <div id="demo" class="collapse">
       <% @reservations.each do |reservation| %>
       <br>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -63,6 +63,8 @@
       <% else %>
         <span class="label label-danger">固定時間未設定</span>
       <% end %>
+      <%= comment_count = Lessoncomment.where("lesson_id =? and student_id =?", reservation.lesson_id, reservation.student_id).count %>
+      <%= "コメント:#{ comment_count } " if comment_count >0 %>
       <%= log_personal_cancel(reservation.cancel) %>
            <%= log_waiting(reservation.waiting) %>
            <%= log_transfer(reservation.transfer) %>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -51,7 +51,7 @@
     <% if @reservations.present? %>
     <div class="bg-warning">
     <div class="panel-heading" data-toggle="collapse" data-target="#demo">
-      <span class="glyphicon glyphicon-envelope" aria-hidden="true"> 予約確認・予約授業へのコメント（遅刻等の連絡、クリックで展開）</div></span>
+      <span class="glyphicon glyphicon-envelope" aria-hidden="true"> 予約授業確認・予約授業へのコメント（遅刻等の連絡、クリックで展開）</div></span>
     <div id="demo" class="collapse">
       <% @reservations.each do |reservation| %>
       <br>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -51,13 +51,18 @@
     <% if @reservations.present? %>
     <div class="bg-warning">
     <div class="panel-heading" data-toggle="collapse" data-target="#demo">
-      <span class="glyphicon glyphicon-envelope" aria-hidden="true"> 予約授業へのコメント（遅刻等の連絡、クリックで展開）</div></span>
+      <span class="glyphicon glyphicon-envelope" aria-hidden="true"> 予約確認・コメント（クリックで展開）</div></span>
     <div id="demo" class="collapse">
       <% @reservations.each do |reservation| %>
       <br>
       <P>・<%= link_to l(reservation.lesson.meeting_on.to_datetime, format: :day_week),"/reservationusers/useredit?lesson_id=#{reservation.lesson.id}&student_id=#{reservation.student.id}" %>
       <%= l(reservation.lesson.started_at, format: :time) %>～<%= l(reservation.lesson.finished_at, format: :time) %>
       <%= reservation.student.student_name %>&nbsp;&nbsp;
+      <% if reservation.fix_time.present? %>
+        固定時間:<%= l( reservation.fix_time, format: :time ) %>
+      <% else %>
+        <span class="label label-danger">固定時間未設定</span>
+      <% end %>
       <%= log_personal_cancel(reservation.cancel) %>
            <%= log_waiting(reservation.waiting) %>
            <%= log_transfer(reservation.transfer) %>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -64,7 +64,7 @@
         <span class="label label-danger">固定時間未設定</span>
       <% end %>
       <% comment_count = Lessoncomment.where("lesson_id =? and student_id =?", reservation.lesson_id, reservation.student_id).count %>
-      <%= "コメント:#{ comment_count } " if comment_count >0 %>
+      <%= "【コメント:#{ comment_count }】" if comment_count >0 %>
       <%= log_personal_cancel(reservation.cancel) %>
            <%= log_waiting(reservation.waiting) %>
            <%= log_transfer(reservation.transfer) %>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -63,7 +63,7 @@
       <% else %>
         <span class="label label-danger">固定時間未設定</span>
       <% end %>
-      <%= comment_count = Lessoncomment.where("lesson_id =? and student_id =?", reservation.lesson_id, reservation.student_id).count %>
+      <% comment_count = Lessoncomment.where("lesson_id =? and student_id =?", reservation.lesson_id, reservation.student_id).count %>
       <%= "コメント:#{ comment_count } " if comment_count >0 %>
       <%= log_personal_cancel(reservation.cancel) %>
            <%= log_waiting(reservation.waiting) %>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -57,12 +57,12 @@
       <br>
       <P>・<%= link_to l(reservation.lesson.meeting_on.to_datetime, format: :day_week),"/reservationusers/useredit?lesson_id=#{reservation.lesson.id}&student_id=#{reservation.student.id}" %>
       <%= l(reservation.lesson.started_at, format: :time) %>～<%= l(reservation.lesson.finished_at, format: :time) %>
-      <%= reservation.student.student_name %>&nbsp;&nbsp;
       <% if reservation.fix_time.present? %>
-        固定時間:<%= l( reservation.fix_time, format: :time ) %>
+        固定時間:<%= l( reservation.fix_time, format: :time ) %>&nbsp;&nbsp;
       <% else %>
-        <span class="label label-danger">固定時間未設定</span>
+        固定時間:未設定
       <% end %>
+      <%= reservation.student.student_name %>&nbsp;&nbsp;
       <% comment_count = Lessoncomment.where("lesson_id =? and student_id =?", reservation.lesson_id, reservation.student_id).count %>
       <%= "【コメント:#{ comment_count }】" if comment_count >0 %>
       <%= log_personal_cancel(reservation.cancel) %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -24,8 +24,8 @@
           <% @questions.each do |question| %>
             <tr id="question-<%= question.id %>">
               <td colspan="2" style="word-wrap:keep-all;"><%= l(question.updated_at, format: :default_2) %></td>
-              <td colspan="1"><%= question.user.guardian %></td>
-              <td colspan="1"><%= User.find(question.destination).guardian %></td>
+              <td colspan="1"><div style="white-space:nowrap;"><%= question.user.guardian %></div></td>
+              <td colspan="1"><div style="white-space:nowrap;"><%= User.find(question.destination).guardian %></div></td>
               <td colspan="3" style="word-wrap:break-word;"><%= link_to question.question_title, question %></td>
               <td colspan="1" style="word-wrap:break-word;"><%=question.answers.count %></td>
               <% if current_user.admin? %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, '問い合わせ一覧') %>
 
-<div class="wrapper_normal">
+<div class="wrapper_middle">
   <h1 id="index">問い合わせ一覧</h1>
   
   <div class="ol-md-12 col-md-offset-0">

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, '問い合わせ一覧') %>
 
-<div class="wrapper_middle">
+<div class="wrapper_normal2">
   <h1 id="index">問い合わせ一覧</h1>
   <div class="button-area" style="text-align: center; margin-bottom:15px;">
     <%= link_to "問い合わせ投稿", new_question_path, class: "btn btn-primary question-btn" %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -2,9 +2,9 @@
 
 <div class="wrapper_middle">
   <h1 id="index">問い合わせ一覧</h1>
-  
-  <div class="ol-md-12 col-md-offset-0">
+  <div class="button-area" style="text-align: center; margin-bottom:15px;">
     <%= link_to "問い合わせ投稿", new_question_path, class: "btn btn-primary question-btn" %>
+  <div class="ol-md-12 col-md-offset-0">
     <% if @questions.present? %>
       <div class="question-paginate"><%= will_paginate %></div>
       <table class="table table-bordered table-condensed" id="table-question" style="table-layout:fixed;">

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="wrapper_normal2">
   <h1 id="index">問い合わせ一覧</h1>
-  <div class="button-area" style="text-align: center; margin-bottom:15px;">
+  <div class="button-area" style="text-align: center; margin-bottom:20px;">
     <%= link_to "問い合わせ投稿", new_question_path, class: "btn btn-primary question-btn" %>
   <div class="ol-md-12 col-md-offset-0">
     <% if @questions.present? %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, '問い合わせ一覧') %>
 
-<div class="wrapper_middle">
+<div class="wrapper_normal2">
   <h1 id="index">問い合わせ一覧</h1>
   <div class="button-area" style="text-align: center; margin-bottom:20px;">
     <%= link_to "問い合わせ投稿", new_question_path, class: "btn btn-primary question-btn" %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, '問い合わせ一覧') %>
 
-<div class="wrapper_normal2">
+<div class="wrapper_middle">
   <h1 id="index">問い合わせ一覧</h1>
   <div class="button-area" style="text-align: center; margin-bottom:20px;">
     <%= link_to "問い合わせ投稿", new_question_path, class: "btn btn-primary question-btn" %>

--- a/app/views/reservation_logs/index.html.erb
+++ b/app/views/reservation_logs/index.html.erb
@@ -12,7 +12,7 @@
 <% if @reservation_logs.present? %>
   <table class="table-log" id="reservations-info">
     <thead>
-      <tr>
+      <tr style="font-size:15px;">
         <th style="width:110px;">授業日</th>
         <th style="width:70px;">授業時間</th>
         <th style="width:40px;"><div style="white-space:nowrap;">固定時間</div></th>

--- a/app/views/reservation_logs/index.html.erb
+++ b/app/views/reservation_logs/index.html.erb
@@ -33,7 +33,7 @@
         <% end %>
         </td>
         <td>
-           <%= l(log.lesson.started_at, format: :time) %>～<%= l(log.lesson.finished_at, format: :time)  %>
+           <div style="white-space:nowrap;"><%= l(log.lesson.started_at, format: :time) %>～<%= l(log.lesson.finished_at, format: :time)  %></ div>
         </td>
         <td>
            <%= l(log.fix_time, format: :time) if log.fix_time.present? %>

--- a/app/views/reservation_logs/index.html.erb
+++ b/app/views/reservation_logs/index.html.erb
@@ -14,11 +14,11 @@
     <thead>
       <tr>
         <th style="width:110px;">授業日</th>
-        <th style="width:100px;">授業時間</th>
-        <th style="width:60px;">固定時間</th>
-        <th style="width:130px;">生徒名</th>
-        <th style="width:40px;">コメント</th>
-        <th style="width:25px;">出席</th>
+        <th style="width:70px;">授業時間</th>
+        <th style="width:40px;"><div style="white-space:nowrap;">固定時間</div></th>
+        <th style="width:100px;">生徒名</th>
+        <th style="width:20px;"><div style="white-space:nowrap;">コメント</div></th>
+        <th style="width:40px;"><div style="white-space:nowrap;">出 席</div></th>
         <th style="width:160px;">備考</th>
       </tr>
     </thead>
@@ -46,7 +46,7 @@
         </td>
         <td style="text-align: center;">
            <%= "済" if log.attendance_time != nil %>
-           <%= "欠" if log.absence? %>
+           <%= "欠席" if log.absence? %>
         </td>
         <td style="text-align: left;">
            <%= log_personal_cancel(log.cancel) %>

--- a/app/views/reservation_logs/index.html.erb
+++ b/app/views/reservation_logs/index.html.erb
@@ -46,7 +46,7 @@
         </td>
         <td style="text-align: center;">
            <%= "済" if log.attendance_time != nil %>
-           <%= "欠席" if log.absence? %>
+           <%= "欠 席" if log.absence? %>
         </td>
         <td style="text-align: left;">
            <%= log_personal_cancel(log.cancel) %>

--- a/app/views/reservationusers/reservationnewuser.html.erb
+++ b/app/views/reservationusers/reservationnewuser.html.erb
@@ -66,12 +66,12 @@
   </tr>
   <% end %>
 </table><br />
+<div class="button-area" style="text-align: center; margin-bottom:15px;">
   <% if @lesson.meeting_on>thisday and @lesson.cancel == false %>
         <%= f.submit "新規登録", class: "btn btn-primary button_size" %>&nbsp;
       <% end %>
     <% end %>
     <%= link_to "ｽｹｼﾞｭｰﾙ" ,"/lessons/weeklyschedule?cation=1&changeday=#{@lesson.meeting_on}",class:"btn btn-info button_size" %>&nbsp;
-    </p>
-    
     </div>
+  </div>
 </div>

--- a/app/views/reservationusers/reservationnewuser.html.erb
+++ b/app/views/reservationusers/reservationnewuser.html.erb
@@ -49,6 +49,12 @@
         <%= f.radio_button :zoom, :false  ,{:checked => true} %> リアル(<%= @realnumber %>/<%= @realseat %>)
         <%= f.radio_button :zoom, :true %>&nbsp;Zoom(<%= @zoomnumber %>/<%= @zoomseat %>)
       <% end %>
+      <% if @real_rest_sheet < 0 %>
+        <span class='label label-danger'>リアルは満席です</span>
+      <% end %>
+      <% if @zoom_rest_sheet < 0 %>
+        <span class='label label-danger'>zoomは満席です</span>
+      <% end %>
       <%= f.hidden_field :reservation_id,value:@reservation.id %>
       <%= f.hidden_field :student_id,value:@student.id %>
       <%= f.hidden_field :lesson_id,value:@lesson.id %>
@@ -66,12 +72,12 @@
   </tr>
   <% end %>
 </table><br />
-<div class="button-area" style="text-align: center; margin-bottom:15px;">
   <% if @lesson.meeting_on>thisday and @lesson.cancel == false %>
         <%= f.submit "新規登録", class: "btn btn-primary button_size" %>&nbsp;
       <% end %>
     <% end %>
     <%= link_to "ｽｹｼﾞｭｰﾙ" ,"/lessons/weeklyschedule?cation=1&changeday=#{@lesson.meeting_on}",class:"btn btn-info button_size" %>&nbsp;
+    </p>
+    
     </div>
-  </div>
 </div>

--- a/app/views/reservationusers/reservationnewuser.html.erb
+++ b/app/views/reservationusers/reservationnewuser.html.erb
@@ -78,8 +78,6 @@
       <% end %>
     <% end %>
     <%= link_to "ｽｹｼﾞｭｰﾙ" ,"/lessons/weeklyschedule?cation=1&changeday=#{@lesson.meeting_on}",class:"btn btn-info button_size" %>&nbsp;
-    </p>
-    
     </div>
 </div>
 </div>

--- a/app/views/reservationusers/reservationnewuser.html.erb
+++ b/app/views/reservationusers/reservationnewuser.html.erb
@@ -49,10 +49,10 @@
         <%= f.radio_button :zoom, :false  ,{:checked => true} %> リアル(<%= @realnumber %>/<%= @realseat %>)
         <%= f.radio_button :zoom, :true %>&nbsp;Zoom(<%= @zoomnumber %>/<%= @zoomseat %>)
       <% end %>
-      <% if @real_rest_sheet < 0 %>
+      <% if @real_rest_sheet <= 0 %>
         <span class='label label-danger'>リアルは満席です</span>
       <% end %>
-      <% if @zoom_rest_sheet < 0 %>
+      <% if @zoom_rest_sheet <= 0 %>
         <span class='label label-danger'>zoomは満席です</span>
       <% end %>
       <%= f.hidden_field :reservation_id,value:@reservation.id %>
@@ -72,6 +72,7 @@
   </tr>
   <% end %>
 </table><br />
+<div class="button-area" style="text-align: center; margin-bottom:20px;">
   <% if @lesson.meeting_on>thisday and @lesson.cancel == false %>
         <%= f.submit "新規登録", class: "btn btn-primary button_size" %>&nbsp;
       <% end %>
@@ -80,4 +81,5 @@
     </p>
     
     </div>
+</div>
 </div>

--- a/app/views/reservationusers/useredit.html.erb
+++ b/app/views/reservationusers/useredit.html.erb
@@ -101,10 +101,10 @@
       <% end %>
     <% end %>
     <div style="display: inline-block;">
-      <%= link_to "ｽｹｼﾞｭｰﾙ" ,lessons_weeklyschedule_path, class:"btn btn-info button_size" %>&nbsp;
+      <%= link_to "ｽｹｼﾞｭｰﾙ" ,"/lessons/weeklyschedule?cation=1&changeday=#{@lesson.meeting_on}",class:"btn btn-info button_size" %>&nbsp;
    </div>
    <div style="display: inline-block;">
-      <%= link_to "予約履歴" ,"/reservation_logs?cation=1&changeday=#{@lesson.meeting_on.beginning_of_month}",class:"btn btn-warning button_size" %>&nbsp
+      <%= link_to "予約履歴" ,"/reservation_logs?cation=1&changeday=#{@lesson.meeting_on.beginning_of_month}",class:"btn btn-warning button_size" %>&nbsp;
     </div>
     <% if current_user.admin? %>
       <div style="display: inline-block;">

--- a/app/views/reservationusers/useredit.html.erb
+++ b/app/views/reservationusers/useredit.html.erb
@@ -101,8 +101,8 @@
       <% end %>
     <% end %>
     <div style="display: inline-block;">
-      <%= link_to "ｽｹｼﾞｭｰﾙ" ,lessons_weeklyschedule_path, class:"btn btn-info button_size" %>&nbsp;
-   </div>
+      <%= link_to "ｽｹｼﾞｭｰﾙ" ,"/lessons/weeklyschedule?cation=1&changeday=#{@lesson.meeting_on}",class:"btn btn-info button_size" %>&nbsp
+    </div>
     <% if current_user.admin? %>
       <div style="display: inline-block;">
       <a href="" data-toggle="modal" data-target=#modal2 class="btn btn-warning button_size">情報修正＊</a>&nbsp;

--- a/app/views/reservationusers/useredit.html.erb
+++ b/app/views/reservationusers/useredit.html.erb
@@ -101,7 +101,10 @@
       <% end %>
     <% end %>
     <div style="display: inline-block;">
-      <%= link_to "ｽｹｼﾞｭｰﾙ" ,"/lessons/weeklyschedule?cation=1&changeday=#{@lesson.meeting_on}",class:"btn btn-info button_size" %>&nbsp
+      <%= link_to "ｽｹｼﾞｭｰﾙ" ,lessons_weeklyschedule_path, class:"btn btn-info button_size" %>&nbsp;
+   </div>
+   <div style="display: inline-block;">
+      <%= link_to "予約履歴" ,"/reservation_logs?cation=1&changeday=#{@lesson.meeting_on.beginning_of_month}",class:"btn btn-warning button_size" %>&nbsp
     </div>
     <% if current_user.admin? %>
       <div style="display: inline-block;">

--- a/app/views/user_mailer/send_mail.html.erb
+++ b/app/views/user_mailer/send_mail.html.erb
@@ -1,6 +1,6 @@
 <% if @send_user.admin == false %>
   
-  <P><%= @send_user.guardian  %>様の情報があります</P>
+  <P><%= @send_user.guardian  %>　様の情報があります</P>
 　
   <p>下記リンクを確認をお願いします</p>
   
@@ -17,6 +17,8 @@
 <% end %>
 
 <p><%= link_to "こちらのリンクを参照下さい。", @link %></p>
+
+<p>こちらのメールアドレスは送信専用です。</p>
 
 
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, 'All users') %>
 <h2 style="font-size:30px;">契約一覧</h2>
 
-<div class="wrapper_normal2">
+<div class="wrapper_middle">
   <div style="display: inline-block;"><%= button_to "契約者", {controller: 'users', action: 'index'}, {method: :get, params: {cation:"1"}} %></div>
   <div style="display: inline-block;"><%= button_to "全表示", {controller: 'users', action: 'index'}, {method: :get, params: {cation:"2"}} %></div>
   <div style="display: inline-block;"><%= button_to "登録順", {controller: 'users', action: 'index'}, {method: :get, params: {cation:"3"}} %></div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,7 @@
 <% provide(:title, 'All users') %>
 <h2 style="font-size:30px;">契約一覧</h2>
 
-<div class="wrapper_middle">
+<div class="wrapper_normal2">
   <div style="display: inline-block;"><%= button_to "契約者", {controller: 'users', action: 'index'}, {method: :get, params: {cation:"1"}} %></div>
   <div style="display: inline-block;"><%= button_to "全表示", {controller: 'users', action: 'index'}, {method: :get, params: {cation:"2"}} %></div>
   <div style="display: inline-block;"><%= button_to "登録順", {controller: 'users', action: 'index'}, {method: :get, params: {cation:"3"}} %></div>


### PR DESCRIPTION
テスト登録してみて　違和感を感じたところ修正しました。
一旦の最終で、連日ですがレビュー及び両方にデプロイお願いします。

予約履歴　画面が小さくなった時一部の列の文字が２行になること回避
管理者予約詳細　　　　〃
問い合わせ　　　　　　〃
予約詳細　予約履歴へのリンク　該当の月へのリンク追加
　　　　　ｽｹｼﾞｭｰﾙ　リンク　詳細の週のスケジュールへのリンク変更（いままでは本日に戻っていた）
予約新規　ｽｹｼﾞｭｰﾙ　リンク　　　　　　　〃
管理者側予約詳細　ｽｹｼﾞｭｰﾙ　リンク　詳細の週のスケジュールへのリンクを追加
　　　　　　　　　予約履歴へのリンク　該当の月へのリンク追加
問い合わせ・契約者一覧　　テーブルの幅を広げる
契約者へのメールアドレス変更　　noreply@email.comへ（旧　noreply@example.com)
契約者へのメール　　リンク参照の文言ダブっていたのでリンクのかかってない方を削除
〃　　　　　　　内容　　　　『こちらのメールアドレスは送信専用です。』を追加
予約履歴の順番を降順→昇順に変更

以上　