### PR TITLE
ユーザー確認用基本情報に固定時間終了の表示追加

### DIFF
--- a/app/views/notices/_basicstudent.html.erb
+++ b/app/views/notices/_basicstudent.html.erb
@@ -32,7 +32,7 @@
                     <th>固定時間</th>
                     <td>
                       <%= student.fix_day %>曜日
-                      <%= student.fix_time.hour %>:<%= mindisplay(student.fix_time) %>～
+                      <%= timedisplay(student.fix_time) %>～<%= timedisplay(student.fix_finishtime) %>
                     </td>
                   </tr>
                   <% if student.fix_day2.present? and student.fix_time2.present? %>
@@ -40,7 +40,7 @@
                       <th>固定時間2</th>
                       <td>
                         <%= student.fix_day2 %>曜日
-                        <%= student.fix_time2.hour %>:<%= mindisplay(student.fix_time2) %>～
+                        <%= timedisplay(student.fix_time2) %>～<%= timedisplay(student.fix_finishtime2) %>
                       </td>
                     </tr>
                     <% end %>
@@ -49,7 +49,7 @@
                           <th>固定時間3</th>
                           <td>
                             <%= student.fix_day3 %>曜日
-                            <%= student.fix_time3.hour %>:<%= mindisplay(student.fix_time3) %>～
+                            <%= timedisplay(student.fix_time3) %>～<%= timedisplay(student.fix_finishtime3) %>
                           </td>
                         </tr>
                         <% end %>
@@ -58,7 +58,7 @@
                           <th>固定時間4</th>
                           <td>
                             <%= student.fix_day4 %>曜日
-                            <%= student.fix_time4.hour %>:<%= mindisplay(student.fix_time4) %>～
+                            <%= timedisplay(student.fix_time4) %>～<%= timedisplay(student.fix_finishtime4) %>
                           </td>
                         </tr>
                         <% end %>
@@ -67,7 +67,7 @@
                           <th>固定時間5</th>
                           <td>
                             <%= student.fix_day5 %>曜日
-                            <%= student.fix_time5.hour %>:<%= mindisplay(student.fix_time5) %>～
+                            <%= timedisplay(student.fix_time5) %>～<%= timedisplay(student.fix_finishtime5) %>
                           </td>
                         </tr>
                         <% end %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -22,7 +22,7 @@
       </span>
     </div>
     <!--内容-->
-    <div class="question-content" style="word-wrap:break-word;"><%= raw(nl2br(@question.question_content)) %></div>
+    <div class="question-content" style="word-wrap:break-word;"><%= simple_format @question.question_content %></div>
   </div>
     
   <div style="text-align:center;">〜 返信  〜</div><br>

--- a/app/views/reservationusers/useredit.html.erb
+++ b/app/views/reservationusers/useredit.html.erb
@@ -45,7 +45,7 @@
   <th>固定時間</th>
   <td>
   <% if @reservation.fix_time.present? %>
-      <%= l(@reservation.fix_time, format: :time) %>～<%= l(@reservation.fix_finishtime, format: :time, default: '-') %>
+      <%= l(@reservation.fix_time, format: :time) %>～<%= l(@reservation.fix_finishtime, format: :time, default: '') %>
     <% else %>
       <span class="label label-danger">未設定</span>
     <% end %>

--- a/app/views/students/_info_edit.erb
+++ b/app/views/students/_info_edit.erb
@@ -64,7 +64,7 @@
                 <td><%= f.time_field :fix_time2 , class: "form-control" %></td>
               </tr>
               <tr>
-                <th>固定終了時間</th>
+                <th>固定終了時間2</th>
                 <td><%= f.time_field :fix_finishtime2 , class: "form-control" %></td>
               </tr>
               


### PR DESCRIPTION
ユーザー確認用基本情報
予約詳細に終了時間がブランク場合　－　表示されるのを修正
問い合わせシステムにタグを貼れるようにした
・・今後　修正履歴兼ね先生に修正情報を報告することを考えているため